### PR TITLE
Add branch-based PR workflow with CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,25 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to add or change?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach
+      description: How might this be implemented? (optional)
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+Closes #<!-- issue number -->
+
+## Changes
+<!-- Bullet list of key changes -->
+
+## Test plan
+<!-- How was this tested? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches-ignore: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: 'latest'
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
+      - run: uv sync --frozen --extra dev
+      - run: uv run pytest --tb=short --junitxml=junit.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: junit.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Push back if the proposed approach seems suboptimal — suggest a better path
 - Flag assumptions being made, especially about intent, scope, or constraints
 
+## Development Workflow
+
+This project uses a branch-based workflow. Do NOT commit directly to main.
+
+1. Work should reference a GitHub issue. Create one if none exists: `gh issue create`
+2. Create a feature branch: `git checkout -b <type>/<issue-number>-<description> main`
+3. Branch prefixes: `feature/`, `fix/`, `docs/`, `refactor/`
+4. Make commits on the branch (imperative mood: "Add...", "Fix...", "Update...")
+5. Push and create a PR: `git push -u origin <branch>` then `gh pr create`
+6. CI must pass before merging (runs full test suite)
+7. Squash merge: `gh pr merge --squash --delete-branch`
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
+
 ## Project Overview
 
 ESG News Classifier for sportswear brands - a multi-label text classification system that categorizes news articles into ESG (Environmental, Social, Governance) categories for 50 sportswear/outdoor brands (see `src/data_collection/config.py` for full list).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing
+
+## Development Workflow
+
+1. **Create or pick a GitHub issue** describing the work
+2. **Create a feature branch** from `main`
+3. **Make commits** on the branch
+4. **Push and open a PR** linking the issue
+5. **CI must pass** (full test suite runs automatically)
+6. **Squash merge** into `main`
+
+## Branch Naming
+
+```
+<type>/<issue-number>-<short-description>
+```
+
+| Type | Use for |
+|------|---------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `refactor/` | Code restructuring without behavior change |
+
+Examples: `feature/12-add-linting`, `fix/15-scraper-timeout`, `docs/9-update-readme`
+
+## Commit Conventions
+
+- Use imperative mood: "Add feature" not "Added feature"
+- Start with an action verb: Add, Fix, Update, Remove, Refactor
+- Keep the first line under 72 characters
+- Add detail in the body when the "why" isn't obvious
+
+## PR Process
+
+1. Link the issue with `Closes #N` in the PR description
+2. CI runs automatically on push — all tests must pass
+3. Use squash merge to keep `main` history clean:
+   ```bash
+   gh pr merge --squash --delete-branch
+   ```
+
+## Testing
+
+```bash
+# Run all tests (required to pass before merge)
+uv run pytest
+
+# Run with verbose output
+uv run pytest -v
+
+# Database tests (requires PostgreSQL, not run in CI)
+RUN_DB_TESTS=1 uv run pytest tests/test_database.py
+```
+
+## Quick Reference
+
+```bash
+# 1. Create issue
+gh issue create --title "Short description" --body "Details"
+
+# 2. Create branch (using issue number from step 1)
+git checkout -b feature/12-short-description main
+
+# 3. Work and commit
+git add <files>
+git commit -m "Add the thing"
+
+# 4. Push and create PR
+git push -u origin feature/12-short-description
+gh pr create --title "Add the thing" --body "Closes #12"
+
+# 5. Wait for CI, then merge
+gh pr checks
+gh pr merge --squash --delete-branch
+```

--- a/README.md
+++ b/README.md
@@ -930,3 +930,7 @@ docker logs esg_news_db
 # Test connection
 psql postgresql://postgres:postgres@localhost:5434/esg_news
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, branching conventions, and PR process.

--- a/tests/test_labeling_pipeline.py
+++ b/tests/test_labeling_pipeline.py
@@ -457,7 +457,9 @@ class TestTransientErrorHandling:
         )
 
         article = self.create_mock_article()
-        result = pipeline._process_article(article, dry_run=True)
+        result = pipeline._process_article(
+            article, dry_run=True, skip_chunking=True, skip_embedding=True
+        )
 
         assert result["error_type"] == "timeout"
         mock_database.update_article_labeling_status.assert_not_called()
@@ -479,7 +481,9 @@ class TestTransientErrorHandling:
         )
 
         article = self.create_mock_article()
-        result = pipeline._process_article(article, dry_run=True)
+        result = pipeline._process_article(
+            article, dry_run=True, skip_chunking=True, skip_embedding=True
+        )
 
         assert result["error_type"] == "authentication"
         mock_database.update_article_labeling_status.assert_not_called()


### PR DESCRIPTION
## Summary

Transition from direct-to-main commits to a branch-based workflow with CI enforcement:
**GitHub Issue → feature branch → PR → CI (tests pass) → squash merge**

Closes #8

## Changes

- **CI workflow** (`.github/workflows/ci.yml`): Runs pytest on PRs to main and pushes to feature branches. Uses uv with dependency caching and uploads JUnit XML results.
- **PR template** (`.github/pull_request_template.md`): Lightweight template with Summary, Changes, and Test plan sections.
- **Issue templates**: Feature request and bug report YAML forms, plus config allowing blank issues.
- **CONTRIBUTING.md**: Single source of truth for the development workflow, branch naming, commit conventions, and quick reference commands.
- **CLAUDE.md**: Added Development Workflow section instructing Claude Code to never commit directly to main.
- **README.md**: Added Contributing section linking to CONTRIBUTING.md.

## Test plan

- [ ] CI workflow triggers on this PR and all 1186 tests pass
- [ ] After merge, configure branch protection requiring the `test` status check
- [ ] Verify direct push to main is rejected after branch protection is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)