### PR TITLE
Add fix_label.py script and improve review-labels skill

### DIFF
--- a/.claude/skills/review-labels/SKILL.md
+++ b/.claude/skills/review-labels/SKILL.md
@@ -125,11 +125,13 @@ with engine.connect() as conn:
 
     # 3. Articles marked false_positive (spot check)
     # Note: FP-classifier-flagged articles have labeled_at=NULL, so use created_at
+    # Content preview uses full_content column (see queries/article_queries.sql for reference)
     print('\n' + '-' * 70)
     print('RECENT FALSE POSITIVES (Spot check for missed ESG content)')
     print('-' * 70)
     result = conn.execute(text('''
-        SELECT a.title, a.source_name, a.url, a.brands_mentioned
+        SELECT a.id, a.title, a.source_name, a.url, a.brands_mentioned,
+               LEFT(a.full_content, 500) as content_preview
         FROM articles a
         WHERE a.labeling_status = 'false_positive'
           AND a.created_at >= :since_date
@@ -141,7 +143,10 @@ with engine.connect() as conn:
         for r in rows:
             brands = ', '.join(r.brands_mentioned) if r.brands_mentioned else 'unknown'
             print(f'  [{r.source_name}] ({brands}) {r.title[:60]}...')
+            print(f'    ID: {r.id}')
             print(f'    URL: {r.url}')
+            if r.content_preview:
+                print(f'    Preview: {r.content_preview[:200]}...')
     else:
         print('  No false positives in this period')
 
@@ -153,7 +158,8 @@ with engine.connect() as conn:
     print('SUBSTANTIVE ANALYST ARTICLES (false_positive -> should be skipped)')
     print('-' * 70)
     result = conn.execute(text('''
-        SELECT id, title, source_name
+        SELECT id, title, source_name,
+               LEFT(full_content, 500) as content_preview
         FROM articles
         WHERE labeling_status = 'false_positive'
           AND created_at >= :since_date
@@ -200,8 +206,11 @@ with engine.connect() as conn:
         for r in rows:
             print(f'  [{r.source_name}] {r.title[:60]}...')
             print(f'    ID: {r.id}')
+            if r.content_preview:
+                print(f'    Preview: {r.content_preview[:200]}...')
         print('  → Verify these contain substantive analyst commentary (not just templates)')
-        print('  → If substantive: change from false_positive to skipped')
+        print('  → To view full article: uv run python scripts/fix_label.py show <ID>')
+        print('  → To fix: uv run python scripts/fix_label.py update <ID> --status skipped')
     else:
         print('  ✓ No mislabeled substantive analyst articles found')
 
@@ -258,18 +267,33 @@ After running the queries:
 
 2. **Negative Sentiment Articles**: Click through to verify the negative sentiment is justified by the article content
 
-3. **False Positives**: Spot check a few to ensure they truly aren't ESG-relevant
+3. **False Positives**: Spot check using the content preview. Remember:
+   - `false_positive` = not actually about the sportswear brand (e.g., "Vans" = vehicles)
+   - `skipped` = genuinely about the brand, but no ESG content (e.g., product reviews, analyst articles)
+   - If an article IS about the brand but was marked `false_positive`, it should be `skipped`
 
 4. **Substantive Analyst Articles**: Per [docs/LABELING.md](../../docs/LABELING.md#stock-article-classification) v1.7.0:
    - **Boilerplate template articles** (MarketBeat, DefenseWorld, DailyPolitical, etc.) → correctly `false_positive` — these are auto-generated aggregations with no original analysis
    - **Substantive analyst articles** (named analysts with specific commentary, original analysis from reputable sources like Reuters, Bloomberg, Seeking Alpha) → should be `skipped`, not `false_positive`
    - The query excludes known boilerplate aggregator sources, so flagged articles are likely genuine mislabels
-   - If flagged articles contain real analyst commentary, fix with:
-     ```sql
-     UPDATE articles SET labeling_status = 'skipped', skipped_at = NOW()
-     WHERE id = 'article-uuid-here';
-     ```
 
 5. **Multi-Brand Articles**: Verify brands in the same article got consistent treatment
+
+## Step 5: Apply Corrections
+
+Use `scripts/fix_label.py` to verify and correct any flagged articles:
+
+```bash
+# View full article details and content for verification
+uv run python scripts/fix_label.py show <article-id>
+
+# Correct one or more articles
+uv run python scripts/fix_label.py update <id> [<id>...] --status skipped
+
+# List valid statuses and their meanings
+uv run python scripts/fix_label.py statuses
+```
+
+For ad-hoc queries, see `queries/article_queries.sql` and `queries/labeling_queries.sql` for reference SQL using the correct schema (e.g., `full_content` column for article text).
 
 Summarize findings and flag any articles that may need relabeling or further investigation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ uv run python scripts/label_articles.py --dry-run --batch-size 5 # Test without 
 uv run python scripts/label_articles.py --batch-size 10          # Label batch of articles
 uv run python scripts/label_articles.py --article-id UUID        # Label specific article
 
+# Label Corrections (after /review-labels)
+uv run python scripts/fix_label.py show <article-id>              # View article details + content
+uv run python scripts/fix_label.py update <id> --status skipped   # Correct labeling status
+uv run python scripts/fix_label.py update <id1> <id2> --status skipped  # Batch update
+uv run python scripts/fix_label.py statuses                       # List valid statuses
+
 # Export Training Data
 uv run python scripts/export_training_data.py --dataset fp       # False positive classifier data
 uv run python scripts/export_training_data.py --dataset esg-prefilter  # ESG pre-filter data

--- a/scripts/fix_label.py
+++ b/scripts/fix_label.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""CLI tool for viewing and correcting article labeling status.
+
+Used after /review-labels to verify flagged articles and apply corrections.
+
+Usage:
+    # Show article details and content preview
+    python scripts/fix_label.py show <article-id>
+
+    # Update one or more articles to a new status
+    python scripts/fix_label.py update <id> [<id>...] --status skipped
+
+    # List valid labeling statuses
+    python scripts/fix_label.py statuses
+
+See also: queries/article_queries.sql, queries/labeling_queries.sql
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.data_collection.database import db
+from src.data_collection.models import Article, BrandLabel, VALID_LABELING_STATUSES
+
+logger = logging.getLogger(__name__)
+
+# Statuses that set specific timestamp fields on transition
+STATUS_TIMESTAMPS = {
+    "skipped": "skipped_at",
+    "labeled": "labeled_at",
+}
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def parse_uuid(value: str) -> UUID:
+    """Parse and validate a UUID string."""
+    try:
+        return UUID(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid UUID: {value}")
+
+
+def show_article(article_id: UUID, content_length: int = 2000) -> bool:
+    """Display article details and content preview.
+
+    Returns True if article was found, False otherwise.
+    """
+    with db.get_session() as session:
+        article = session.query(Article).filter(Article.id == article_id).first()
+        if not article:
+            print(f"Article not found: {article_id}")
+            return False
+
+        print("=" * 70)
+        print(f"Title:   {article.title}")
+        print(f"Source:  {article.source_name}")
+        print(f"URL:     {article.url}")
+        print(f"Status:  {article.labeling_status}")
+        print(f"Brands:  {', '.join(article.brands_mentioned) if article.brands_mentioned else 'none'}")
+
+        if article.published_at:
+            print(f"Published: {article.published_at.strftime('%Y-%m-%d')}")
+        if article.labeled_at:
+            print(f"Labeled:   {article.labeled_at.strftime('%Y-%m-%d %H:%M')}")
+        if article.skipped_at:
+            print(f"Skipped:   {article.skipped_at.strftime('%Y-%m-%d %H:%M')}")
+
+        # Brand labels
+        labels = (
+            session.query(BrandLabel)
+            .filter(BrandLabel.article_id == article_id)
+            .all()
+        )
+        if labels:
+            print(f"\nBrand Labels ({len(labels)}):")
+            for bl in labels:
+                sentiments = []
+                if bl.environmental_sentiment is not None:
+                    sentiments.append(f"E:{bl.environmental_sentiment:+d}")
+                if bl.social_sentiment is not None:
+                    sentiments.append(f"S:{bl.social_sentiment:+d}")
+                if bl.governance_sentiment is not None:
+                    sentiments.append(f"G:{bl.governance_sentiment:+d}")
+                if bl.digital_sentiment is not None:
+                    sentiments.append(f"D:{bl.digital_sentiment:+d}")
+                print(f"  {bl.brand}: {' '.join(sentiments)} (confidence: {bl.confidence_score})")
+
+        # Content preview
+        if article.full_content:
+            preview = article.full_content[:content_length]
+            if len(article.full_content) > content_length:
+                preview += f"\n... [{len(article.full_content) - content_length} more chars]"
+            print(f"\nContent ({len(article.full_content)} chars):")
+            print("-" * 70)
+            print(preview)
+        else:
+            print("\nContent: [no full_content available]")
+
+        print("=" * 70)
+        return True
+
+
+def update_articles(article_ids: list[UUID], new_status: str) -> tuple[int, int]:
+    """Update labeling status for one or more articles.
+
+    Returns (updated_count, not_found_count).
+    """
+    if new_status not in VALID_LABELING_STATUSES:
+        print(f"Invalid status: {new_status}")
+        print(f"Valid statuses: {', '.join(VALID_LABELING_STATUSES)}")
+        return 0, len(article_ids)
+
+    now = datetime.now(timezone.utc)
+    updated = 0
+    not_found = 0
+
+    with db.get_session() as session:
+        for article_id in article_ids:
+            article = session.query(Article).filter(Article.id == article_id).first()
+            if not article:
+                print(f"  Not found: {article_id}")
+                not_found += 1
+                continue
+
+            old_status = article.labeling_status
+            if old_status == new_status:
+                print(f"  Already {new_status}: {article.title[:60]}")
+                continue
+
+            # Update status
+            article.labeling_status = new_status
+
+            # Set appropriate timestamp
+            timestamp_field = STATUS_TIMESTAMPS.get(new_status)
+            if timestamp_field:
+                setattr(article, timestamp_field, now)
+
+            print(f"  {old_status} -> {new_status}: {article.title[:60]}")
+            updated += 1
+
+        if updated > 0:
+            session.commit()
+
+    return updated, not_found
+
+
+def list_statuses() -> None:
+    """Print valid labeling statuses with descriptions."""
+    descriptions = {
+        "pending": "Awaiting processing",
+        "chunked": "Text chunked, awaiting embedding",
+        "embedded": "Embeddings generated, awaiting labeling",
+        "labeled": "Successfully labeled with ESG categories",
+        "skipped": "Genuine brand article, no ESG content (e.g., product reviews, analyst articles)",
+        "false_positive": "Not actually about the sportswear brand (e.g., 'Vans' = vehicles)",
+        "unlabelable": "Could not be labeled (insufficient content, language issues)",
+        "deduplicated": "Duplicate of another article",
+    }
+    print("Valid labeling statuses:")
+    print("-" * 70)
+    for status in VALID_LABELING_STATUSES:
+        desc = descriptions.get(status, "")
+        print(f"  {status:<16} {desc}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="View and correct article labeling status",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Show article details
+    %(prog)s show 12345678-1234-1234-1234-123456789abc
+
+    # Update articles to skipped
+    %(prog)s update ID1 ID2 --status skipped
+
+    # List valid statuses
+    %(prog)s statuses
+        """,
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # show subcommand
+    show_parser = subparsers.add_parser("show", help="Show article details and content preview")
+    show_parser.add_argument("article_id", type=parse_uuid, help="Article UUID")
+    show_parser.add_argument(
+        "--content-length",
+        type=int,
+        default=2000,
+        help="Max characters of content to show (default: 2000)",
+    )
+
+    # update subcommand
+    update_parser = subparsers.add_parser("update", help="Update article labeling status")
+    update_parser.add_argument(
+        "article_ids",
+        type=parse_uuid,
+        nargs="+",
+        help="One or more article UUIDs",
+    )
+    update_parser.add_argument(
+        "--status",
+        required=True,
+        choices=VALID_LABELING_STATUSES,
+        help="New labeling status",
+    )
+
+    # statuses subcommand
+    subparsers.add_parser("statuses", help="List valid labeling statuses")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point."""
+    args = parse_args()
+    setup_logging(args.verbose)
+
+    if args.command == "show":
+        found = show_article(args.article_id, args.content_length)
+        sys.exit(0 if found else 1)
+
+    elif args.command == "update":
+        updated, not_found = update_articles(args.article_ids, args.status)
+        print(f"\nUpdated: {updated}, Not found: {not_found}")
+        sys.exit(0 if not_found == 0 else 1)
+
+    elif args.command == "statuses":
+        list_statuses()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_collection/models.py
+++ b/src/data_collection/models.py
@@ -29,6 +29,18 @@ class Base(DeclarativeBase):
     pass
 
 
+VALID_LABELING_STATUSES = [
+    "pending",
+    "chunked",
+    "embedded",
+    "labeled",
+    "skipped",
+    "false_positive",
+    "unlabelable",
+    "deduplicated",
+]
+
+
 class Article(Base):
     """News article from NewsData.io API."""
 
@@ -61,7 +73,7 @@ class Article(Base):
     embedding = Column(Vector(1536))
 
     # Labeling status tracking
-    # Valid statuses: pending, chunked, embedded, labeled, skipped, false_positive, unlabelable, deduplicated
+    # Valid statuses defined in VALID_LABELING_STATUSES
     labeling_status = Column(String(20), default="pending")
     labeling_error = Column(Text)
     labeled_at = Column(DateTime(timezone=True))

--- a/tests/test_fix_label.py
+++ b/tests/test_fix_label.py
@@ -1,0 +1,369 @@
+"""Tests for scripts/fix_label.py - article label correction tool."""
+
+import uuid
+from datetime import datetime, timezone
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.fix_label import (
+    STATUS_TIMESTAMPS,
+    list_statuses,
+    parse_uuid,
+    show_article,
+    update_articles,
+)
+from src.data_collection.models import VALID_LABELING_STATUSES
+
+
+# ============================================================================
+# VALID_LABELING_STATUSES constant tests
+# ============================================================================
+
+
+class TestValidLabelingStatuses:
+    """Tests for VALID_LABELING_STATUSES constant in models.py."""
+
+    def test_contains_expected_statuses(self):
+        """All expected statuses are present."""
+        expected = {
+            "pending",
+            "chunked",
+            "embedded",
+            "labeled",
+            "skipped",
+            "false_positive",
+            "unlabelable",
+            "deduplicated",
+        }
+        assert set(VALID_LABELING_STATUSES) == expected
+
+    def test_is_list(self):
+        """Constant is a list (ordered)."""
+        assert isinstance(VALID_LABELING_STATUSES, list)
+
+    def test_no_duplicates(self):
+        """No duplicate entries."""
+        assert len(VALID_LABELING_STATUSES) == len(set(VALID_LABELING_STATUSES))
+
+
+# ============================================================================
+# parse_uuid tests
+# ============================================================================
+
+
+class TestParseUuid:
+    """Tests for UUID parsing and validation."""
+
+    def test_valid_uuid(self):
+        """Accepts a valid UUID string."""
+        result = parse_uuid("12345678-1234-1234-1234-123456789abc")
+        assert isinstance(result, uuid.UUID)
+
+    def test_invalid_uuid(self):
+        """Rejects invalid UUID strings."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid UUID"):
+            parse_uuid("not-a-uuid")
+
+    def test_empty_string(self):
+        """Rejects empty string."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            parse_uuid("")
+
+
+# ============================================================================
+# STATUS_TIMESTAMPS tests
+# ============================================================================
+
+
+class TestStatusTimestamps:
+    """Tests for timestamp mapping."""
+
+    def test_skipped_sets_skipped_at(self):
+        assert STATUS_TIMESTAMPS["skipped"] == "skipped_at"
+
+    def test_labeled_sets_labeled_at(self):
+        assert STATUS_TIMESTAMPS["labeled"] == "labeled_at"
+
+    def test_other_statuses_have_no_timestamp(self):
+        """Statuses not in the map don't set extra timestamps."""
+        for status in VALID_LABELING_STATUSES:
+            if status not in ("skipped", "labeled"):
+                assert status not in STATUS_TIMESTAMPS
+
+
+# ============================================================================
+# show_article tests
+# ============================================================================
+
+
+def _make_mock_article(**overrides):
+    """Create a mock Article with sensible defaults."""
+    article = MagicMock()
+    article.id = overrides.get("id", uuid.uuid4())
+    article.title = overrides.get("title", "Test Article Title")
+    article.source_name = overrides.get("source_name", "Test Source")
+    article.url = overrides.get("url", "https://example.com/article")
+    article.labeling_status = overrides.get("labeling_status", "pending")
+    article.brands_mentioned = overrides.get("brands_mentioned", ["Nike"])
+    article.published_at = overrides.get("published_at", datetime(2026, 4, 1))
+    article.labeled_at = overrides.get("labeled_at", None)
+    article.skipped_at = overrides.get("skipped_at", None)
+    article.full_content = overrides.get("full_content", "Article content here.")
+    return article
+
+
+class TestShowArticle:
+    """Tests for show_article function."""
+
+    @patch("scripts.fix_label.db")
+    def test_article_not_found(self, mock_db):
+        """Returns False when article doesn't exist."""
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = None
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = show_article(uuid.uuid4())
+        assert result is False
+
+    @patch("scripts.fix_label.db")
+    def test_article_found(self, mock_db, capsys):
+        """Returns True and prints details when article exists."""
+        article = _make_mock_article(
+            title="Nike Sustainability Report",
+            source_name="Reuters",
+            labeling_status="false_positive",
+        )
+
+        session = MagicMock()
+        # First query returns the article, second returns empty brand labels
+        session.query.return_value.filter.return_value.first.return_value = article
+        session.query.return_value.filter.return_value.all.return_value = []
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = show_article(article.id)
+        assert result is True
+
+        output = capsys.readouterr().out
+        assert "Nike Sustainability Report" in output
+        assert "Reuters" in output
+        assert "false_positive" in output
+
+    @patch("scripts.fix_label.db")
+    def test_content_truncation(self, mock_db, capsys):
+        """Content is truncated to specified length."""
+        long_content = "x" * 5000
+        article = _make_mock_article(full_content=long_content)
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        session.query.return_value.filter.return_value.all.return_value = []
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = show_article(article.id, content_length=100)
+        assert result is True
+
+        output = capsys.readouterr().out
+        assert "4900 more chars" in output
+
+    @patch("scripts.fix_label.db")
+    def test_no_content(self, mock_db, capsys):
+        """Handles articles with no full_content."""
+        article = _make_mock_article(full_content=None)
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        session.query.return_value.filter.return_value.all.return_value = []
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = show_article(article.id)
+        output = capsys.readouterr().out
+        assert "no full_content available" in output
+
+    @patch("scripts.fix_label.db")
+    def test_brand_labels_displayed(self, mock_db, capsys):
+        """Brand labels are shown when present."""
+        article = _make_mock_article()
+
+        brand_label = MagicMock()
+        brand_label.brand = "Nike"
+        brand_label.environmental_sentiment = 1
+        brand_label.social_sentiment = -1
+        brand_label.governance_sentiment = None
+        brand_label.digital_sentiment = 0
+        brand_label.confidence_score = 0.85
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        session.query.return_value.filter.return_value.all.return_value = [brand_label]
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        show_article(article.id)
+        output = capsys.readouterr().out
+        assert "Nike" in output
+        assert "E:+1" in output
+        assert "S:-1" in output
+        assert "D:+0" in output
+        assert "0.85" in output
+
+    @patch("scripts.fix_label.db")
+    def test_no_brands_mentioned(self, mock_db, capsys):
+        """Handles articles with no brands_mentioned."""
+        article = _make_mock_article(brands_mentioned=None)
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        session.query.return_value.filter.return_value.all.return_value = []
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        show_article(article.id)
+        output = capsys.readouterr().out
+        assert "Brands:  none" in output
+
+
+# ============================================================================
+# update_articles tests
+# ============================================================================
+
+
+class TestUpdateArticles:
+    """Tests for update_articles function."""
+
+    @patch("scripts.fix_label.db")
+    def test_invalid_status_rejected(self, mock_db, capsys):
+        """Returns early for invalid status values."""
+        updated, not_found = update_articles([uuid.uuid4()], "invalid_status")
+        assert updated == 0
+        assert not_found == 1
+
+        output = capsys.readouterr().out
+        assert "Invalid status" in output
+
+    @patch("scripts.fix_label.db")
+    def test_article_not_found(self, mock_db, capsys):
+        """Counts not-found articles."""
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = None
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        updated, not_found = update_articles([uuid.uuid4()], "skipped")
+        assert updated == 0
+        assert not_found == 1
+
+    @patch("scripts.fix_label.db")
+    def test_successful_update(self, mock_db, capsys):
+        """Updates article status and sets timestamp."""
+        article = _make_mock_article(labeling_status="false_positive")
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        updated, not_found = update_articles([article.id], "skipped")
+        assert updated == 1
+        assert not_found == 0
+        assert article.labeling_status == "skipped"
+        assert article.skipped_at is not None
+        session.commit.assert_called_once()
+
+    @patch("scripts.fix_label.db")
+    def test_already_same_status(self, mock_db, capsys):
+        """Skips articles already at target status."""
+        article = _make_mock_article(labeling_status="skipped")
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        updated, not_found = update_articles([article.id], "skipped")
+        assert updated == 0
+        output = capsys.readouterr().out
+        assert "Already skipped" in output
+        session.commit.assert_not_called()
+
+    @patch("scripts.fix_label.db")
+    def test_batch_update(self, mock_db, capsys):
+        """Updates multiple articles in one call."""
+        articles = [
+            _make_mock_article(id=uuid.uuid4(), labeling_status="false_positive"),
+            _make_mock_article(id=uuid.uuid4(), labeling_status="false_positive"),
+        ]
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.side_effect = articles
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        ids = [a.id for a in articles]
+        updated, not_found = update_articles(ids, "skipped")
+        assert updated == 2
+        assert not_found == 0
+        session.commit.assert_called_once()
+
+    @patch("scripts.fix_label.db")
+    def test_no_timestamp_for_pending(self, mock_db):
+        """Statuses without timestamp mapping don't set extra fields."""
+        article = _make_mock_article(labeling_status="false_positive")
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        update_articles([article.id], "pending")
+        assert article.labeling_status == "pending"
+        # skipped_at and labeled_at should not have been set
+        # (MagicMock attrs are auto-created, so check setattr wasn't called for these)
+
+    @patch("scripts.fix_label.db")
+    def test_labeled_sets_labeled_at(self, mock_db):
+        """Updating to 'labeled' sets labeled_at timestamp."""
+        article = _make_mock_article(labeling_status="pending")
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = article
+        mock_db.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        mock_db.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        update_articles([article.id], "labeled")
+        assert article.labeling_status == "labeled"
+        assert article.labeled_at is not None
+
+
+# ============================================================================
+# list_statuses tests
+# ============================================================================
+
+
+class TestListStatuses:
+    """Tests for list_statuses function."""
+
+    def test_prints_all_statuses(self, capsys):
+        """All valid statuses appear in output."""
+        list_statuses()
+        output = capsys.readouterr().out
+
+        for status in VALID_LABELING_STATUSES:
+            assert status in output
+
+    def test_includes_descriptions(self, capsys):
+        """Output includes descriptive text."""
+        list_statuses()
+        output = capsys.readouterr().out
+
+        assert "Awaiting processing" in output
+        assert "Not actually about the sportswear brand" in output


### PR DESCRIPTION
## Summary

Closes #12

- Add `scripts/fix_label.py` CLI tool for viewing article details (`show`) and correcting labeling status (`update`) with proper validation and timestamp handling
- Extract `VALID_LABELING_STATUSES` constant in `src/data_collection/models.py` as single source of truth (was only a comment)
- Improve `review-labels` skill: add content previews (`full_content`) to flagged article queries, replace raw SQL correction instructions with `fix_label.py` references, add `queries/` folder as reference for ad-hoc queries

## Test plan

- [x] 24 new tests in `tests/test_fix_label.py` (all passing)
- [x] Full test suite passes (1186 passed, 24 skipped)
- [x] Smoke tested `fix_label.py show` and `statuses` commands against live DB
- [ ] Run `/review-labels` with updated skill to verify content previews appear
- [ ] Test `fix_label.py update` on a test article (change status, verify timestamp set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)