### PR TITLE
Add Claude Code security hooks for secret protection

### DIFF
--- a/.claude/hooks/block_secret_reads.py
+++ b/.claude/hooks/block_secret_reads.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block reads of files likely to contain credentials.
+
+Receives the PreToolUse event JSON on stdin. Denies the tool call when the
+target file path (or Bash command argument) matches known credential files:
+.env variants, shell rc files, SSH private keys, and named secrets files.
+
+Emits a JSON decision on stdout and exits 0 (the modern pattern); exit 2
++ stderr is the legacy fallback but not used here.
+
+Cross-platform: stdlib only, no shell dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import PurePath
+
+# The BLOCKED_BASENAMES set and the CREDENTIAL_TOKEN_PATTERNS list must stay in
+# sync — they express the same credential-file list in two matching contexts
+# (exact basename vs. substring-in-command-or-pattern). Update both together.
+BLOCKED_BASENAMES: frozenset[str] = frozenset(
+    {
+        ".env",
+        ".envrc",
+        "credentials",
+        "credentials.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "secrets.json",
+        ".bashrc",
+        ".bash_profile",
+        ".profile",
+        ".zshrc",
+        ".zshenv",
+        ".zprofile",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "id_dsa",
+    }
+)
+
+BLOCKED_SUFFIXES: frozenset[str] = frozenset({".pem"})
+
+CREDENTIAL_TOKEN_PATTERNS: list[str] = [
+    r"\.env(\b|[._-][A-Za-z0-9_-]+)",
+    r"\.envrc\b",
+    r"credentials\.json\b",
+    r"secrets\.ya?ml\b",
+    r"secrets\.json\b",
+    r"\.bashrc\b",
+    r"\.bash_profile\b",
+    r"\.profile\b",
+    r"\.zshrc\b",
+    r"\.zshenv\b",
+    r"\.zprofile\b",
+    r"\bid_rsa\b",
+    r"\bid_ed25519\b",
+    r"\bid_ecdsa\b",
+    r"\bid_dsa\b",
+    r"\.pem\b",
+]
+CREDENTIAL_TOKEN_REGEX = re.compile("|".join(CREDENTIAL_TOKEN_PATTERNS), re.IGNORECASE)
+
+FILE_PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
+PATH_SEARCH_TOOLS = {"Grep", "Glob"}
+
+DENY_REASON = (
+    "Blocked by AgentFluent secrets-protection hook (.claude/hooks/block_secret_reads.py). "
+    "This file is a likely credential source (.env, shell rc, SSH key, or named secrets file). "
+    "Reading it would persist its contents in the Claude Code session JSONL. "
+    "If you need to verify the file exists, use `test -f <path>`. "
+    "See docs/SECURITY.md for the full policy."
+)
+
+
+def path_is_blocked(path_str: str) -> bool:
+    if not path_str:
+        return False
+    p = PurePath(path_str)
+    name = p.name
+    if name in BLOCKED_BASENAMES:
+        return True
+    if p.suffix in BLOCKED_SUFFIXES:
+        return True
+    if name.startswith((".env.", ".env-", ".env_")):
+        return True
+    return False
+
+
+def bash_command_is_blocked(command: str) -> bool:
+    if not command:
+        return False
+    return CREDENTIAL_TOKEN_REGEX.search(command) is not None
+
+
+def check(event: dict) -> tuple[bool, str]:
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input") or {}
+
+    if tool_name in FILE_PATH_TOOLS:
+        path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+        if path_is_blocked(path):
+            return True, f"{DENY_REASON} (path: {path})"
+
+    if tool_name in PATH_SEARCH_TOOLS:
+        path = tool_input.get("path") or ""
+        pattern = tool_input.get("pattern") or ""
+        if path and path_is_blocked(path):
+            return True, f"{DENY_REASON} (search path: {path})"
+        if pattern and CREDENTIAL_TOKEN_REGEX.search(pattern):
+            return True, f"{DENY_REASON} (search pattern targets credential file: {pattern})"
+
+    if tool_name == "Bash":
+        command = tool_input.get("command") or ""
+        if bash_command_is_blocked(command):
+            return True, f"{DENY_REASON} (command: {command[:200]})"
+
+    return False, ""
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        # Fail closed: this is a security-critical PreToolUse hook. If we can't
+        # parse the event we cannot confirm the call is safe, so deny rather
+        # than allow through a malformed event of unknown provenance.
+        print(
+            f"block_secret_reads: failed to parse hook event JSON, denying by default: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    blocked, reason = check(event)
+    if blocked:
+        emit_decision("deny", reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/detect_secrets_in_output.py
+++ b/.claude/hooks/detect_secrets_in_output.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: block Claude from reasoning about tool output with secrets.
+
+PostToolUse cannot redact non-MCP tool output inline. Instead, this hook uses
+the detect-and-block pattern: if the tool response contains a known API key
+or token pattern, it emits `{"decision": "block", "reason": ...}` so Claude
+Code surfaces a block signal alongside the result and Claude knows not to
+echo, summarize, or otherwise act on the leaked value.
+
+Caveat: PostToolUse fires AFTER the tool has executed. The raw output is
+already persisted in the session JSONL, and Claude still technically receives
+the tool_result in-session. This hook prevents further propagation (summaries,
+follow-up prompts quoting the value) but does NOT prevent the on-disk leak.
+The PreToolUse block_secret_reads.py hook is the primary defense against
+on-disk leakage; this is a secondary guard.
+
+Cross-platform: stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), "anthropic-key"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}"), "openai-project-key"),
+    (re.compile(r"sk-[A-Za-z0-9]{40,}"), "openai-key-legacy"),
+    (re.compile(r"ghp_[A-Za-z0-9]{30,}"), "github-pat-classic"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{40,}"), "github-pat-fine"),
+    (re.compile(r"AKIA[A-Z0-9]{16}"), "aws-access-key-id"),
+    (re.compile(r"AIza[A-Za-z0-9_-]{35}"), "gcp-api-key"),
+]
+
+DENY_REASON_TEMPLATE = (
+    "Blocked by AgentFluent secrets-protection hook "
+    "(.claude/hooks/detect_secrets_in_output.py). "
+    "Tool output contained a value matching a known credential pattern: {kinds}. "
+    "Claude is being prevented from reasoning about this output to avoid further "
+    "propagation (e.g. echoing in summaries). "
+    "IMPORTANT: the raw value has already been persisted in the session JSONL "
+    "because PostToolUse fires after tool execution. Rotate any key that may have "
+    "leaked and see docs/SECURITY.md for full remediation steps."
+)
+
+
+def stringify_response(resp: object) -> str:
+    """Coerce tool_response (dict, list, str, etc.) into a single searchable string."""
+    if isinstance(resp, str):
+        return resp
+    try:
+        return json.dumps(resp, default=str)
+    except (TypeError, ValueError):
+        return str(resp)
+
+
+def find_secret_kinds(text: str) -> list[str]:
+    kinds: list[str] = []
+    for pattern, label in SECRET_PATTERNS:
+        if pattern.search(text):
+            kinds.append(label)
+    return kinds
+
+
+def emit_block(reason: str) -> None:
+    payload = {"decision": "block", "reason": reason}
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(
+            f"detect_secrets_in_output: failed to parse hook event JSON: {e}",
+            file=sys.stderr,
+        )
+        return 0
+
+    response = event.get("tool_response")
+    if response is None:
+        return 0
+
+    text = stringify_response(response)
+    kinds = find_secret_kinds(text)
+    if kinds:
+        reason = DENY_REASON_TEMPLATE.format(kinds=", ".join(sorted(set(kinds))))
+        emit_block(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write|Grep|Glob|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block_secret_reads.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/detect_secrets_in_output.py"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `PreToolUse` hook (`block_secret_reads.py`) that denies reads of common credential-source paths before contents enter the session transcript.
- Add `PostToolUse` hook (`detect_secrets_in_output.py`) that scans tool output for known secret patterns and blocks echo.
- Wire both into `.claude/settings.json` for Read/Edit/Write/Grep/Glob/NotebookEdit/Bash (Pre) and Read/Grep/Bash (Post).

## Why

Closes #25. Especially relevant now that we've started using AgentFluent (epic #14), which reads `~/.claude/projects/*.jsonl` — once a secret is in the session transcript, `.gitignore` doesn't help. These hooks are the same pattern AgentFluent ships with.

## Test plan

- [ ] Hooks fire on attempted reads of `.env` / shell rc files (verify by attempting `cat .env` — should be blocked)
- [ ] Hooks fire on tool output containing known secret patterns (sanity test)
- [ ] Existing test suite still passes (`uv run pytest`)
- [ ] Hooks have executable bit set (`ls -l .claude/hooks/*.py` shows `x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
