### PR TITLE
Fix website export pushing to wrong branch (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,7 +396,7 @@ git worktree add ../frederick-douglas-pearce.github.io-feed main
 # AGENT_WEBSITE_REPO_PATH=/home/fdpearce/Documents/Projects/git/github_pages/frederick-douglas-pearce.github.io-feed
 ```
 
-The workflow asserts the worktree is on `main`, fast-forward-pulls before committing, and pushes with an explicit `origin HEAD:main` refspec. If any guard fails the workflow aborts and sends an error notification rather than pushing to the wrong branch.
+The workflow's first step (`prepare_worktree`) asserts the worktree is on `main` and fast-forward-pulls BEFORE `export_feeds` writes any files (so the FF pull never has to contend with uncommitted feed changes). `commit_and_push` then runs a defense-in-depth branch check, scopes its status check to the two feed paths, and pushes with an explicit `origin HEAD:main` refspec. Any failure causes `send_error_notification` to dispatch an alert and raise, so the workflow ends in `WorkflowStatus.FAILED` rather than masquerading as a clean run. Set `AGENT_WEBSITE_EXPECTED_BRANCH` if your publishing branch is not `main`.
 
 ### Export Commands
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,19 @@ GitHub Actions → Google Cloud Run. Secrets: `GCP_PROJECT_ID`, `GCP_SA_KEY`, `G
 
 JSON/Atom feeds for Jekyll/al-folio site. Website repo: `/home/fdpearce/Documents/Projects/git/github_pages/frederick-douglas-pearce.github.io`
 
+### Worktree Setup (one-time)
+
+The `website_export` cron workflow must run in a dedicated git worktree pinned to `main`, separate from any interactive checkout. This isolates unattended pushes from in-progress feature-branch work.
+
+```bash
+cd /home/fdpearce/Documents/Projects/git/github_pages/frederick-douglas-pearce.github.io
+git worktree add ../frederick-douglas-pearce.github.io-feed main
+# Then point AGENT_WEBSITE_REPO_PATH at the new worktree path:
+# AGENT_WEBSITE_REPO_PATH=/home/fdpearce/Documents/Projects/git/github_pages/frederick-douglas-pearce.github.io-feed
+```
+
+The workflow asserts the worktree is on `main`, fast-forward-pulls before committing, and pushes with an explicit `origin HEAD:main` refspec. If any guard fails the workflow aborts and sends an error notification rather than pushing to the wrong branch.
+
 ### Export Commands
 ```bash
 # Full export with scorecard (default)

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -96,6 +96,9 @@ class AgentSettings:
         if (p := os.getenv("AGENT_WEBSITE_REPO_PATH"))
         else None
     )
+    website_expected_branch: str = field(
+        default_factory=lambda: os.getenv("AGENT_WEBSITE_EXPECTED_BRANCH", "main")
+    )
 
     def __post_init__(self) -> None:
         """Ensure directories exist."""

--- a/src/agent/workflows/website_export.py
+++ b/src/agent/workflows/website_export.py
@@ -170,8 +170,21 @@ def validate_export(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
     return validation_result
 
 
+# The export workflow is expected to run inside a dedicated git worktree
+# pinned to this branch. Pushes go to origin/<EXPECTED_BRANCH> only.
+EXPECTED_BRANCH = "main"
+
+
 def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
-    """Commit and push changes to the website repository."""
+    """Commit and push changes to the website repository.
+
+    Assumes `website_repo_path` is a worktree pinned to `EXPECTED_BRANCH`.
+    Three guards prevent the unattended workflow from pushing to the wrong
+    branch when a shared working tree drifts off main:
+      1. Branch assertion (abort if HEAD is not EXPECTED_BRANCH)
+      2. Fast-forward pull (abort if origin moved non-linearly)
+      3. Explicit refspec push (no reliance on upstream tracking)
+    """
     if context.get("export_skipped") or context.get("validation_skipped"):
         return {"git_skipped": True, "reason": "export_skipped"}
 
@@ -187,7 +200,46 @@ def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
         logger.info("Dry run - skipping git commit and push")
         return {"git_skipped": True, "reason": "dry_run"}
 
-    # Check if there are changes to commit
+    # Guard 1: assert we are on EXPECTED_BRANCH before touching anything
+    branch_result = run_script(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=website_repo,
+        retries=0,
+    )
+    if not branch_result.success:
+        logger.error(f"Could not determine current branch: {branch_result.stderr}")
+        return {"git_success": False, "error": "git_branch_check_failed"}
+
+    current_branch = branch_result.stdout.strip()
+    if current_branch != EXPECTED_BRANCH:
+        logger.error(
+            f"Refusing to push: website repo is on '{current_branch}', "
+            f"expected '{EXPECTED_BRANCH}'. The export workflow must run in a "
+            f"worktree pinned to '{EXPECTED_BRANCH}' (see CLAUDE.md)."
+        )
+        return {
+            "git_success": False,
+            "error": "wrong_branch",
+            "current_branch": current_branch,
+            "expected_branch": EXPECTED_BRANCH,
+        }
+
+    # Guard 2: fast-forward pull so we don't push on top of a stale base.
+    # Refuse to merge — a cron job should never resolve divergence.
+    pull_result = run_script(
+        ["git", "pull", "--ff-only", "origin", EXPECTED_BRANCH],
+        cwd=website_repo,
+        retries=0,
+        timeout=60,
+    )
+    if not pull_result.success:
+        logger.error(
+            f"Fast-forward pull of origin/{EXPECTED_BRANCH} failed: "
+            f"{pull_result.stderr}"
+        )
+        return {"git_success": False, "error": "git_pull_ff_failed"}
+
+    # Check if there are changes to commit (after pull, in case pull pulled them in)
     status_result = run_script(
         ["git", "status", "--porcelain"],
         cwd=website_repo,
@@ -233,9 +285,11 @@ def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
         logger.error(f"Git commit failed: {commit_result.stderr}")
         return {"git_success": False, "error": "git_commit_failed"}
 
-    # Push
+    # Guard 3: push with an explicit refspec instead of bare `git push`.
+    # This is independent of any upstream tracking config and pins the
+    # destination to origin/EXPECTED_BRANCH.
     push_result = run_script(
-        ["git", "push"],
+        ["git", "push", "origin", f"HEAD:{EXPECTED_BRANCH}"],
         cwd=website_repo,
         retries=1,
         timeout=60,
@@ -249,6 +303,7 @@ def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
     return {
         "git_success": True,
         "commit_message": f"Update ESG news feed - {today}",
+        "branch": EXPECTED_BRANCH,
     }
 
 
@@ -271,7 +326,22 @@ def send_error_notification(workflow: Workflow, context: dict[str, Any]) -> dict
 
     # Check git step
     if context.get("git_success") is False:
-        errors.append(f"Git operation failed: {context.get('error', 'Unknown error')}")
+        git_error = context.get("error", "Unknown error")
+        if git_error == "wrong_branch":
+            errors.append(
+                f"Git operation failed: website repo is on "
+                f"'{context.get('current_branch')}', expected "
+                f"'{context.get('expected_branch')}'. Workflow must run in a "
+                f"worktree pinned to the expected branch (see CLAUDE.md)."
+            )
+        elif git_error == "git_pull_ff_failed":
+            errors.append(
+                "Git operation failed: fast-forward pull rejected. The "
+                "website repo's local branch has diverged from origin; "
+                "resolve manually before the next scheduled run."
+            )
+        else:
+            errors.append(f"Git operation failed: {git_error}")
 
     # No errors - silent success
     if not errors:

--- a/src/agent/workflows/website_export.py
+++ b/src/agent/workflows/website_export.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 def export_feeds(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
     """Export JSON and Atom feeds for the website."""
+    if context.get("prepare_ready") is False:
+        return {"export_skipped": True, "reason": "prepare_failed"}
+
     website_repo = agent_settings.website_repo_path
 
     if not website_repo:
@@ -170,26 +173,121 @@ def validate_export(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
     return validation_result
 
 
-# The export workflow is expected to run inside a dedicated git worktree
-# pinned to this branch. Pushes go to origin/<EXPECTED_BRANCH> only.
-EXPECTED_BRANCH = "main"
+# Files written by export_feeds and committed by commit_and_push.
+# Kept as a module-level constant so prepare_worktree and commit_and_push
+# can both reason about the same paths.
+_FEED_FILES = ("_data/esg_news.json", "assets/feeds/esg_news.atom")
+
+
+class WorkflowError(RuntimeError):
+    """Raised by the final notification step so the workflow ends in FAILED state."""
+
+
+def _check_branch(
+    website_repo: Path, expected: str
+) -> tuple[bool, str | None, str | None, str]:
+    """Run `git symbolic-ref --short HEAD` and return (ok, branch, error_code, stderr).
+
+    - ok=True, branch=<name>, error_code=None, stderr=""  -> on expected branch
+    - ok=False, branch=<name>, error_code="wrong_branch"   -> on a different branch
+    - ok=False, branch=None,  error_code="git_branch_check_failed" -> command itself failed
+    """
+    result = run_script(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=website_repo,
+        retries=0,
+        dry_run=False,
+    )
+    if not result.success:
+        return False, None, "git_branch_check_failed", result.stderr
+    current = result.stdout.strip()
+    if current != expected:
+        return False, current, "wrong_branch", ""
+    return True, current, None, ""
+
+
+def prepare_worktree(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
+    """Verify the worktree is on the expected branch and fast-forward it.
+
+    Runs BEFORE export_feeds so the FF pull never has to contend with the
+    files export_feeds is about to overwrite. Failures set
+    `prepare_ready: False` and an `error` code; downstream steps short-circuit
+    on that flag, and `send_error_notification` raises so the workflow ends
+    in FAILED state.
+    """
+    website_repo = agent_settings.website_repo_path
+    if not website_repo:
+        return {"prepare_skipped": True, "reason": "website_repo_not_configured"}
+
+    dry_run = context.get("dry_run", False)
+    if dry_run:
+        logger.info("Dry run - skipping worktree preparation")
+        return {"prepare_skipped": True, "reason": "dry_run"}
+
+    expected = agent_settings.website_expected_branch
+
+    ok, current_branch, error_code, branch_stderr = _check_branch(website_repo, expected)
+    if not ok:
+        if error_code == "wrong_branch":
+            logger.error(
+                f"Refusing to proceed: website repo is on '{current_branch}', "
+                f"expected '{expected}'. The export workflow must run in a "
+                f"worktree pinned to '{expected}' (see CLAUDE.md)."
+            )
+        else:
+            logger.error(f"Could not determine current branch: {branch_stderr}")
+        return {
+            "prepare_ready": False,
+            "error": error_code,
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": branch_stderr[:500] if branch_stderr else "",
+        }
+
+    pull_result = run_script(
+        ["git", "pull", "--ff-only", "origin", expected],
+        cwd=website_repo,
+        retries=1,
+        dry_run=False,
+        timeout=60,
+    )
+    if not pull_result.success:
+        logger.error(
+            f"Fast-forward pull of origin/{expected} failed: {pull_result.stderr}"
+        )
+        return {
+            "prepare_ready": False,
+            "error": "git_pull_ff_failed",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": pull_result.stderr[:500],
+        }
+
+    return {
+        "prepare_ready": True,
+        "current_branch": current_branch,
+        "expected_branch": expected,
+    }
 
 
 def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
-    """Commit and push changes to the website repository.
+    """Stage, commit, and push the exported feed files.
 
-    Assumes `website_repo_path` is a worktree pinned to `EXPECTED_BRANCH`.
-    Three guards prevent the unattended workflow from pushing to the wrong
-    branch when a shared working tree drifts off main:
-      1. Branch assertion (abort if HEAD is not EXPECTED_BRANCH)
-      2. Fast-forward pull (abort if origin moved non-linearly)
-      3. Explicit refspec push (no reliance on upstream tracking)
+    Assumes `prepare_worktree` has already verified the branch and pulled.
+    Performs a defense-in-depth branch check in case anything raced between
+    the two steps, then stages only the feed files, commits, and pushes with
+    an explicit `origin HEAD:<branch>` refspec. Every error return includes
+    `current_branch`, `expected_branch`, and a `git_stderr` snippet for the
+    notification step to render.
     """
     if context.get("export_skipped") or context.get("validation_skipped"):
         return {"git_skipped": True, "reason": "export_skipped"}
 
     if not context.get("validation_passed", False):
         return {"git_skipped": True, "reason": "validation_failed"}
+
+    if context.get("prepare_ready") is False:
+        return {"git_skipped": True, "reason": "prepare_failed"}
 
     website_repo = agent_settings.website_repo_path
     if not website_repo:
@@ -200,166 +298,236 @@ def commit_and_push(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
         logger.info("Dry run - skipping git commit and push")
         return {"git_skipped": True, "reason": "dry_run"}
 
-    # Guard 1: assert we are on EXPECTED_BRANCH before touching anything
-    branch_result = run_script(
-        ["git", "symbolic-ref", "--short", "HEAD"],
-        cwd=website_repo,
-        retries=0,
-    )
-    if not branch_result.success:
-        logger.error(f"Could not determine current branch: {branch_result.stderr}")
-        return {"git_success": False, "error": "git_branch_check_failed"}
+    expected = agent_settings.website_expected_branch
 
-    current_branch = branch_result.stdout.strip()
-    if current_branch != EXPECTED_BRANCH:
-        logger.error(
-            f"Refusing to push: website repo is on '{current_branch}', "
-            f"expected '{EXPECTED_BRANCH}'. The export workflow must run in a "
-            f"worktree pinned to '{EXPECTED_BRANCH}' (see CLAUDE.md)."
-        )
+    # Defense-in-depth branch check in case state changed between
+    # prepare_worktree and this step (e.g., an operator touched the worktree).
+    ok, current_branch, error_code, branch_stderr = _check_branch(website_repo, expected)
+    if not ok:
         return {
             "git_success": False,
-            "error": "wrong_branch",
+            "error": error_code,
             "current_branch": current_branch,
-            "expected_branch": EXPECTED_BRANCH,
+            "expected_branch": expected,
+            "git_stderr": branch_stderr[:500] if branch_stderr else "",
         }
 
-    # Guard 2: fast-forward pull so we don't push on top of a stale base.
-    # Refuse to merge — a cron job should never resolve divergence.
-    pull_result = run_script(
-        ["git", "pull", "--ff-only", "origin", EXPECTED_BRANCH],
-        cwd=website_repo,
-        retries=0,
-        timeout=60,
-    )
-    if not pull_result.success:
-        logger.error(
-            f"Fast-forward pull of origin/{EXPECTED_BRANCH} failed: "
-            f"{pull_result.stderr}"
-        )
-        return {"git_success": False, "error": "git_pull_ff_failed"}
-
-    # Check if there are changes to commit (after pull, in case pull pulled them in)
+    # Scope status to the feed files we actually care about. Any other dirty
+    # state (operator poking around) is intentionally ignored here.
     status_result = run_script(
-        ["git", "status", "--porcelain"],
+        ["git", "status", "--porcelain", "--", *_FEED_FILES],
         cwd=website_repo,
         retries=0,
+        dry_run=False,
     )
+    if not status_result.success:
+        logger.error(f"git status failed: {status_result.stderr}")
+        return {
+            "git_success": False,
+            "error": "git_status_failed",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": status_result.stderr[:500],
+        }
 
     if not status_result.stdout.strip():
         logger.info("No changes to commit")
-        return {"git_skipped": True, "reason": "no_changes"}
+        return {
+            "git_skipped": True,
+            "reason": "no_changes",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+        }
 
-    # Run prettier to format JSON file before committing
+    # Format the JSON feed; warning only — prettier absence shouldn't block.
     prettier_result = run_script(
         ["npx", "prettier", "--write", "_data/esg_news.json"],
         cwd=website_repo,
         retries=0,
+        dry_run=False,
         timeout=60,
     )
-
     if not prettier_result.success:
         logger.warning(f"Prettier formatting failed: {prettier_result.stderr}")
-        # Continue anyway - prettier failure shouldn't block the export
 
-    # Add files
     add_result = run_script(
-        ["git", "add", "_data/esg_news.json", "assets/feeds/esg_news.atom"],
+        ["git", "add", *_FEED_FILES],
         cwd=website_repo,
         retries=0,
+        dry_run=False,
     )
-
     if not add_result.success:
         logger.error(f"Git add failed: {add_result.stderr}")
-        return {"git_success": False, "error": "git_add_failed"}
+        return {
+            "git_success": False,
+            "error": "git_add_failed",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": add_result.stderr[:500],
+        }
 
-    # Commit
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     commit_result = run_script(
         ["git", "commit", "-m", f"Update ESG news feed - {today}"],
         cwd=website_repo,
         retries=0,
+        dry_run=False,
     )
-
     if not commit_result.success:
         logger.error(f"Git commit failed: {commit_result.stderr}")
-        return {"git_success": False, "error": "git_commit_failed"}
+        return {
+            "git_success": False,
+            "error": "git_commit_failed",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": commit_result.stderr[:500],
+        }
 
-    # Guard 3: push with an explicit refspec instead of bare `git push`.
-    # This is independent of any upstream tracking config and pins the
-    # destination to origin/EXPECTED_BRANCH.
+    # Push with an explicit refspec, no upstream tracking dependency.
+    # No retry: the commit stays local, the next scheduled run handles
+    # any transient or non-FF condition cleanly via prepare_worktree.
     push_result = run_script(
-        ["git", "push", "origin", f"HEAD:{EXPECTED_BRANCH}"],
+        ["git", "push", "origin", f"HEAD:{expected}"],
         cwd=website_repo,
-        retries=1,
+        retries=0,
+        dry_run=False,
         timeout=60,
     )
-
     if not push_result.success:
         logger.error(f"Git push failed: {push_result.stderr}")
-        return {"git_success": False, "error": "git_push_failed"}
+        return {
+            "git_success": False,
+            "error": "git_push_failed",
+            "current_branch": current_branch,
+            "expected_branch": expected,
+            "git_stderr": push_result.stderr[:500],
+        }
 
     logger.info("Successfully committed and pushed to website repo")
     return {
         "git_success": True,
         "commit_message": f"Update ESG news feed - {today}",
-        "branch": EXPECTED_BRANCH,
+        "branch": expected,
+        "current_branch": current_branch,
+        "expected_branch": expected,
     }
 
 
-def send_error_notification(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
-    """Send email notification only if there was an error during export.
+def _describe_git_error(context: dict[str, Any], git_error: str) -> str:
+    """Build a human-readable description of a git failure code.
 
-    This step checks for failures in previous steps and sends an alert email
-    if any issues were detected. Successful exports are silent.
+    Includes a stderr snippet when present so transient/auth/dirty-tree
+    failures don't all look like 'branch diverged'.
+    """
+    current = context.get("current_branch")
+    expected = context.get("expected_branch")
+    stderr = (context.get("git_stderr") or "").strip()
+    stderr_suffix = f" git stderr: {stderr}" if stderr else ""
+
+    if git_error == "wrong_branch":
+        return (
+            f"website repo is on '{current}', expected '{expected}'. "
+            f"Workflow must run in a worktree pinned to the expected "
+            f"branch (see CLAUDE.md)."
+        )
+    if git_error == "git_branch_check_failed":
+        return (
+            f"could not determine current branch of website repo "
+            f"(expected '{expected}'). This usually means the worktree is "
+            f"in detached HEAD, mid-rebase, or `.git` is corrupted.{stderr_suffix}"
+        )
+    if git_error == "git_pull_ff_failed":
+        return (
+            f"fast-forward pull of origin/{expected} failed. Causes include "
+            f"divergence from origin, uncommitted local changes blocking the "
+            f"merge, network failure, or authentication failure. The next "
+            f"scheduled run will retry if the cause was transient.{stderr_suffix}"
+        )
+    if git_error == "git_status_failed":
+        return (
+            f"`git status` failed in the website repo. A stale `.git/index.lock` "
+            f"from an interrupted git process is the most common cause; "
+            f"inspect and remove it if no git process is running.{stderr_suffix}"
+        )
+    if git_error == "git_add_failed":
+        return f"`git add` of the feed files failed.{stderr_suffix}"
+    if git_error == "git_commit_failed":
+        return (
+            f"`git commit` failed — usually because the staged set was empty "
+            f"or commit signing/hooks rejected the change.{stderr_suffix}"
+        )
+    if git_error == "git_push_failed":
+        return (
+            f"`git push origin HEAD:{expected}` failed. If the remote moved "
+            f"between the FF pull and the push (TOCTOU), the next scheduled "
+            f"run will rebase and push.{stderr_suffix}"
+        )
+    return f"unknown git error code '{git_error}'.{stderr_suffix}"
+
+
+def send_error_notification(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]:
+    """Aggregate failures across prior steps, notify, and raise on failure.
+
+    Raises WorkflowError when any prior step recorded a failure so the
+    workflow base class marks the run as FAILED — without this, returning a
+    notification dict makes the step COMPLETED and the whole workflow status
+    incorrectly reports clean success.
     """
     errors = []
+    wrong_branch_only = True  # toggled off when any other failure is also present
 
-    # Check export step
+    # prepare_worktree
+    if context.get("prepare_ready") is False:
+        prep_error = context.get("error", "Unknown prepare error")
+        errors.append(f"Worktree preparation failed: {_describe_git_error(context, prep_error)}")
+        if prep_error != "wrong_branch":
+            wrong_branch_only = False
+
+    # export
     if not context.get("export_success", True) and not context.get("export_skipped"):
         errors.append(f"Export failed: {context.get('export_error', 'Unknown error')}")
+        wrong_branch_only = False
 
-    # Check validation step
+    # validation
     if not context.get("validation_passed", True) and not context.get("validation_skipped"):
         validation_errors = context.get("errors", [])
         errors.append(f"Validation failed: {', '.join(validation_errors)}")
+        wrong_branch_only = False
 
-    # Check git step
+    # scorecard snapshot
+    if context.get("scorecard_saved") is False:
+        scorecard_error = context.get("error", "Unknown error")
+        errors.append(f"Scorecard snapshot save failed: {scorecard_error}")
+        wrong_branch_only = False
+
+    # commit/push
     if context.get("git_success") is False:
         git_error = context.get("error", "Unknown error")
-        if git_error == "wrong_branch":
-            errors.append(
-                f"Git operation failed: website repo is on "
-                f"'{context.get('current_branch')}', expected "
-                f"'{context.get('expected_branch')}'. Workflow must run in a "
-                f"worktree pinned to the expected branch (see CLAUDE.md)."
-            )
-        elif git_error == "git_pull_ff_failed":
-            errors.append(
-                "Git operation failed: fast-forward pull rejected. The "
-                "website repo's local branch has diverged from origin; "
-                "resolve manually before the next scheduled run."
-            )
-        else:
-            errors.append(f"Git operation failed: {git_error}")
+        errors.append(f"Git operation failed: {_describe_git_error(context, git_error)}")
+        if git_error != "wrong_branch":
+            wrong_branch_only = False
 
-    # No errors - silent success
     if not errors:
         logger.info("Website export completed successfully - no notification needed")
         return {"notification_sent": False, "reason": "no_errors"}
 
-    # Build error notification
     error_message = "\n".join(f"• {e}" for e in errors)
-    details = {
+    details: dict[str, Any] = {
+        "prepare_ready": context.get("prepare_ready", "N/A"),
         "export_success": context.get("export_success", "N/A"),
         "validation_passed": context.get("validation_passed", "N/A"),
+        "scorecard_saved": context.get("scorecard_saved", "N/A"),
         "git_success": context.get("git_success", "N/A"),
     }
 
-    if context.get("json_output"):
-        details["json_output"] = context.get("json_output")
-    if context.get("atom_output"):
-        details["atom_output"] = context.get("atom_output")
+    # Only surface feed paths in details when push actually attempted/succeeded.
+    # When the only failure is wrong_branch, the feed files were written locally
+    # but never pushed — including the paths reads as misleadingly successful.
+    if not wrong_branch_only:
+        if context.get("json_output"):
+            details["json_output"] = context.get("json_output")
+        if context.get("atom_output"):
+            details["atom_output"] = context.get("atom_output")
 
     notification = Notification(
         notification_type=NotificationType.WORKFLOW_FAILED,
@@ -369,18 +537,17 @@ def send_error_notification(workflow: Workflow, context: dict[str, Any]) -> dict
         severity="error",
     )
 
-    # Send notification
     manager = NotificationManager()
     result = manager.send(notification)
-
     channels_used = [k for k, v in result.items() if v]
     logger.warning(f"Sent error notification via: {channels_used}")
 
-    return {
-        "notification_sent": True,
-        "errors": errors,
-        "channels": channels_used,
-    }
+    # Raise so Workflow.run records the run as FAILED. The notification has
+    # already been sent; the exception only changes workflow-level status.
+    raise WorkflowError(
+        f"Website export workflow failed with {len(errors)} error(s); "
+        f"notification dispatched via {channels_used or 'no channels'}."
+    )
 
 
 @WorkflowRegistry.register
@@ -388,17 +555,24 @@ class WebsiteExportWorkflow(Workflow):
     """Website feed export workflow.
 
     Steps:
-    1. Export JSON and Atom feeds
-    2. Save scorecard snapshot to database
-    3. Validate exported files
-    4. Commit and push to website repository
-    5. Send error notification (only if there was a failure)
+    1. Prepare worktree (assert branch, fast-forward pull) - BEFORE any writes
+    2. Export JSON and Atom feeds
+    3. Save scorecard snapshot to database
+    4. Validate exported files
+    5. Commit and push to website repository
+    6. Send error notification (raises so workflow status reflects failure)
     """
 
     name = "website_export"
     description = "Export ESG news feeds to website repository"
 
     steps = [
+        StepDefinition(
+            name="prepare_worktree",
+            description="Assert worktree branch and fast-forward pull before any writes",
+            handler=prepare_worktree,
+            skip_on_dry_run=True,
+        ),
         StepDefinition(
             name="export_feeds",
             description="Export JSON and Atom feeds to website repository",
@@ -423,7 +597,7 @@ class WebsiteExportWorkflow(Workflow):
         ),
         StepDefinition(
             name="send_error_notification",
-            description="Send email notification if export failed",
+            description="Aggregate errors, notify, and raise so workflow status reflects failure",
             handler=send_error_notification,
             skip_on_dry_run=True,
         ),

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -524,3 +524,204 @@ class TestWebsiteExportWorkflow:
             s for s in WebsiteExportWorkflow.steps if s.name == "commit_and_push"
         )
         assert commit_step.skip_on_dry_run is True
+
+
+def _script_result(
+    command: list[str],
+    *,
+    exit_code: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> Any:
+    """Build a ScriptResult-shaped object for patching run_script."""
+    from src.agent.runner import ScriptResult
+
+    return ScriptResult(
+        command=command,
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        duration_seconds=0.0,
+        started_at=datetime.now(timezone.utc),
+    )
+
+
+class TestCommitAndPushGuards:
+    """Tests for the three guards in commit_and_push()."""
+
+    @pytest.fixture
+    def passing_context(self):
+        return {
+            "export_skipped": False,
+            "validation_skipped": False,
+            "validation_passed": True,
+            "dry_run": False,
+            "json_output": "/tmp/esg_news.json",
+            "atom_output": "/tmp/esg_news.atom",
+        }
+
+    @patch("src.agent.workflows.website_export.agent_settings")
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_aborts_when_not_on_expected_branch(
+        self, mock_run_script, mock_settings, passing_context, tmp_path
+    ):
+        """Guard 1: refuse to push from any branch other than EXPECTED_BRANCH."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_settings.website_repo_path = tmp_path
+
+        # Only the branch-check call should run; everything after must abort.
+        mock_run_script.return_value = _script_result(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            stdout="feature/agentfluent-baseline-post\n",
+        )
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_success"] is False
+        assert result["error"] == "wrong_branch"
+        assert result["current_branch"] == "feature/agentfluent-baseline-post"
+        assert result["expected_branch"] == "main"
+
+        # Only the branch-check ran; no git add/commit/push attempted.
+        assert mock_run_script.call_count == 1
+
+    @patch("src.agent.workflows.website_export.agent_settings")
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_aborts_when_ff_pull_fails(
+        self, mock_run_script, mock_settings, passing_context, tmp_path
+    ):
+        """Guard 2: refuse to proceed if fast-forward pull fails."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_settings.website_repo_path = tmp_path
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
+            ),
+            _script_result(
+                ["git", "pull", "--ff-only", "origin", "main"],
+                exit_code=1,
+                stderr="fatal: Not possible to fast-forward, aborting.\n",
+            ),
+        ]
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_success"] is False
+        assert result["error"] == "git_pull_ff_failed"
+
+        # Branch check + FF pull; nothing further.
+        assert mock_run_script.call_count == 2
+
+    @patch("src.agent.workflows.website_export.agent_settings")
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_pushes_with_explicit_refspec_on_happy_path(
+        self, mock_run_script, mock_settings, passing_context, tmp_path
+    ):
+        """Guard 3: push uses 'origin HEAD:main', not bare 'git push'."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_settings.website_repo_path = tmp_path
+
+        mock_run_script.side_effect = [
+            _script_result(  # branch check
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
+            ),
+            _script_result(  # ff pull
+                ["git", "pull", "--ff-only", "origin", "main"]
+            ),
+            _script_result(  # status -- changes present
+                ["git", "status", "--porcelain"], stdout=" M _data/esg_news.json\n"
+            ),
+            _script_result(  # prettier
+                ["npx", "prettier", "--write", "_data/esg_news.json"]
+            ),
+            _script_result(  # add
+                ["git", "add", "_data/esg_news.json", "assets/feeds/esg_news.atom"]
+            ),
+            _script_result(["git", "commit"]),
+            _script_result(["git", "push"]),
+        ]
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_success"] is True
+        assert result["branch"] == "main"
+
+        push_call = mock_run_script.call_args_list[-1]
+        push_command = push_call.args[0] if push_call.args else push_call.kwargs["command"]
+        assert push_command == ["git", "push", "origin", "HEAD:main"]
+
+    @patch("src.agent.workflows.website_export.agent_settings")
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_skips_when_pull_pulled_in_pending_changes(
+        self, mock_run_script, mock_settings, passing_context, tmp_path
+    ):
+        """If FF pull leaves the working tree clean, treat as no-op (not failure)."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_settings.website_repo_path = tmp_path
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
+            ),
+            _script_result(["git", "pull", "--ff-only", "origin", "main"]),
+            _script_result(["git", "status", "--porcelain"], stdout=""),
+        ]
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_skipped"] is True
+        assert result["reason"] == "no_changes"
+
+
+class TestSendErrorNotificationGuards:
+    """Tests that the new git error types render user-facing messages."""
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_wrong_branch_error_mentions_worktree(self, mock_manager_cls):
+        from src.agent.workflows.website_export import send_error_notification
+
+        mock_manager = MagicMock()
+        mock_manager.send.return_value = {"email": True}
+        mock_manager_cls.return_value = mock_manager
+
+        context = {
+            "export_success": True,
+            "validation_passed": True,
+            "git_success": False,
+            "error": "wrong_branch",
+            "current_branch": "feature/foo",
+            "expected_branch": "main",
+        }
+
+        result = send_error_notification(MagicMock(), context)
+
+        assert result["notification_sent"] is True
+        sent_notification = mock_manager.send.call_args.args[0]
+        assert "feature/foo" in sent_notification.message
+        assert "worktree" in sent_notification.message.lower()
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_ff_pull_error_mentions_divergence(self, mock_manager_cls):
+        from src.agent.workflows.website_export import send_error_notification
+
+        mock_manager = MagicMock()
+        mock_manager.send.return_value = {"email": True}
+        mock_manager_cls.return_value = mock_manager
+
+        context = {
+            "export_success": True,
+            "validation_passed": True,
+            "git_success": False,
+            "error": "git_pull_ff_failed",
+        }
+
+        result = send_error_notification(MagicMock(), context)
+
+        assert result["notification_sent"] is True
+        sent_notification = mock_manager.send.call_args.args[0]
+        assert "diverged" in sent_notification.message.lower()

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -546,55 +546,79 @@ def _script_result(
     )
 
 
-class TestCommitAndPushGuards:
-    """Tests for the three guards in commit_and_push()."""
+@pytest.fixture
+def mock_website_settings(tmp_path):
+    """Patch agent_settings with explicit attributes — no MagicMock auto-attrs."""
+    with patch("src.agent.workflows.website_export.agent_settings") as m:
+        m.website_repo_path = tmp_path
+        m.website_expected_branch = "main"
+        yield m
 
-    @pytest.fixture
-    def passing_context(self):
-        return {
-            "export_skipped": False,
-            "validation_skipped": False,
-            "validation_passed": True,
-            "dry_run": False,
-            "json_output": "/tmp/esg_news.json",
-            "atom_output": "/tmp/esg_news.atom",
-        }
 
-    @patch("src.agent.workflows.website_export.agent_settings")
+class TestPrepareWorktree:
+    """Tests for the prepare_worktree step (branch assertion + FF pull)."""
+
     @patch("src.agent.workflows.website_export.run_script")
-    def test_aborts_when_not_on_expected_branch(
-        self, mock_run_script, mock_settings, passing_context, tmp_path
-    ):
-        """Guard 1: refuse to push from any branch other than EXPECTED_BRANCH."""
-        from src.agent.workflows.website_export import commit_and_push
+    def test_skips_when_website_repo_not_configured(self, mock_run_script):
+        from src.agent.workflows.website_export import prepare_worktree
 
-        mock_settings.website_repo_path = tmp_path
+        with patch("src.agent.workflows.website_export.agent_settings") as m:
+            m.website_repo_path = None
+            result = prepare_worktree(MagicMock(), {})
 
-        # Only the branch-check call should run; everything after must abort.
-        mock_run_script.return_value = _script_result(
-            ["git", "symbolic-ref", "--short", "HEAD"],
-            stdout="feature/agentfluent-baseline-post\n",
-        )
+        assert result == {"prepare_skipped": True, "reason": "website_repo_not_configured"}
+        assert mock_run_script.call_count == 0
 
-        result = commit_and_push(MagicMock(), passing_context)
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_skips_on_dry_run(self, mock_run_script, mock_website_settings):
+        from src.agent.workflows.website_export import prepare_worktree
 
-        assert result["git_success"] is False
+        result = prepare_worktree(MagicMock(), {"dry_run": True})
+
+        assert result == {"prepare_skipped": True, "reason": "dry_run"}
+        assert mock_run_script.call_count == 0
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_fails_on_wrong_branch(self, mock_run_script, mock_website_settings):
+        from src.agent.workflows.website_export import prepare_worktree
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"],
+                stdout="feature/agentfluent-baseline-post\n",
+            ),
+            AssertionError("should not pull after wrong-branch abort"),
+        ]
+
+        result = prepare_worktree(MagicMock(), {})
+
+        assert result["prepare_ready"] is False
         assert result["error"] == "wrong_branch"
         assert result["current_branch"] == "feature/agentfluent-baseline-post"
         assert result["expected_branch"] == "main"
-
-        # Only the branch-check ran; no git add/commit/push attempted.
         assert mock_run_script.call_count == 1
 
-    @patch("src.agent.workflows.website_export.agent_settings")
     @patch("src.agent.workflows.website_export.run_script")
-    def test_aborts_when_ff_pull_fails(
-        self, mock_run_script, mock_settings, passing_context, tmp_path
+    def test_fails_when_branch_check_command_fails(
+        self, mock_run_script, mock_website_settings
     ):
-        """Guard 2: refuse to proceed if fast-forward pull fails."""
-        from src.agent.workflows.website_export import commit_and_push
+        from src.agent.workflows.website_export import prepare_worktree
 
-        mock_settings.website_repo_path = tmp_path
+        mock_run_script.return_value = _script_result(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            exit_code=1,
+            stderr="fatal: ref HEAD is not a symbolic ref\n",
+        )
+
+        result = prepare_worktree(MagicMock(), {})
+
+        assert result["prepare_ready"] is False
+        assert result["error"] == "git_branch_check_failed"
+        assert "symbolic ref" in result["git_stderr"]
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_fails_when_ff_pull_fails(self, mock_run_script, mock_website_settings):
+        from src.agent.workflows.website_export import prepare_worktree
 
         mock_run_script.side_effect = [
             _script_result(
@@ -607,40 +631,149 @@ class TestCommitAndPushGuards:
             ),
         ]
 
+        result = prepare_worktree(MagicMock(), {})
+
+        assert result["prepare_ready"] is False
+        assert result["error"] == "git_pull_ff_failed"
+        assert "fast-forward" in result["git_stderr"]
+        assert result["current_branch"] == "main"
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_runs_BEFORE_export_writes_anything(
+        self, mock_run_script, mock_website_settings
+    ):
+        """prepare_worktree must be cwd-pure: branch check + pull, no fs writes."""
+        from src.agent.workflows.website_export import prepare_worktree
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
+            ),
+            _script_result(["git", "pull", "--ff-only", "origin", "main"]),
+        ]
+
+        result = prepare_worktree(MagicMock(), {})
+
+        assert result["prepare_ready"] is True
+        # All commands run via run_script, no direct file writes
+        commands = [call.args[0] for call in mock_run_script.call_args_list]
+        for cmd in commands:
+            assert cmd[0] == "git"
+        # FF pull was the second call
+        assert commands[1] == ["git", "pull", "--ff-only", "origin", "main"]
+
+
+class TestCommitAndPushGuards:
+    """Tests for commit_and_push() after the prepare_worktree refactor."""
+
+    @pytest.fixture
+    def passing_context(self):
+        return {
+            "export_skipped": False,
+            "validation_skipped": False,
+            "validation_passed": True,
+            "prepare_ready": True,
+            "dry_run": False,
+            "json_output": "/tmp/esg_news.json",
+            "atom_output": "/tmp/esg_news.atom",
+        }
+
+    def test_skips_when_prepare_failed(self, passing_context):
+        from src.agent.workflows.website_export import commit_and_push
+
+        ctx = dict(passing_context, prepare_ready=False)
+        result = commit_and_push(MagicMock(), ctx)
+
+        assert result == {"git_skipped": True, "reason": "prepare_failed"}
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_defense_in_depth_branch_check(
+        self, mock_run_script, mock_website_settings, passing_context
+    ):
+        """If branch flipped between prepare_worktree and commit_and_push, abort."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"],
+                stdout="feature/sneak-in\n",
+            ),
+            AssertionError("must not stage/commit after wrong-branch abort"),
+        ]
+
         result = commit_and_push(MagicMock(), passing_context)
 
         assert result["git_success"] is False
-        assert result["error"] == "git_pull_ff_failed"
+        assert result["error"] == "wrong_branch"
+        assert result["current_branch"] == "feature/sneak-in"
 
-        # Branch check + FF pull; nothing further.
-        assert mock_run_script.call_count == 2
-
-    @patch("src.agent.workflows.website_export.agent_settings")
     @patch("src.agent.workflows.website_export.run_script")
-    def test_pushes_with_explicit_refspec_on_happy_path(
-        self, mock_run_script, mock_settings, passing_context, tmp_path
+    def test_fails_when_status_command_fails(
+        self, mock_run_script, mock_website_settings, passing_context
     ):
-        """Guard 3: push uses 'origin HEAD:main', not bare 'git push'."""
+        """git status failure must not be silently treated as no_changes."""
         from src.agent.workflows.website_export import commit_and_push
 
-        mock_settings.website_repo_path = tmp_path
-
         mock_run_script.side_effect = [
-            _script_result(  # branch check
+            _script_result(
                 ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
             ),
-            _script_result(  # ff pull
-                ["git", "pull", "--ff-only", "origin", "main"]
+            _script_result(
+                ["git", "status", "--porcelain", "--", "_data/esg_news.json",
+                 "assets/feeds/esg_news.atom"],
+                exit_code=128,
+                stderr="fatal: Unable to create '.git/index.lock': File exists.\n",
             ),
-            _script_result(  # status -- changes present
-                ["git", "status", "--porcelain"], stdout=" M _data/esg_news.json\n"
+            AssertionError("must not proceed after status failure"),
+        ]
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_success"] is False
+        assert result["error"] == "git_status_failed"
+        assert "index.lock" in result["git_stderr"]
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_skips_when_no_feed_changes(
+        self, mock_run_script, mock_website_settings, passing_context
+    ):
+        """Empty status output scoped to feed files = no commit needed."""
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_run_script.side_effect = [
+            _script_result(
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
             ),
-            _script_result(  # prettier
-                ["npx", "prettier", "--write", "_data/esg_news.json"]
+            _script_result(
+                ["git", "status", "--porcelain", "--", "_data/esg_news.json",
+                 "assets/feeds/esg_news.atom"],
+                stdout="",
             ),
-            _script_result(  # add
-                ["git", "add", "_data/esg_news.json", "assets/feeds/esg_news.atom"]
+        ]
+
+        result = commit_and_push(MagicMock(), passing_context)
+
+        assert result["git_skipped"] is True
+        assert result["reason"] == "no_changes"
+
+    @patch("src.agent.workflows.website_export.run_script")
+    def test_pushes_with_explicit_refspec_on_happy_path(
+        self, mock_run_script, mock_website_settings, passing_context
+    ):
+        from src.agent.workflows.website_export import commit_and_push
+
+        mock_run_script.side_effect = [
+            _script_result(  # defense-in-depth branch check
+                ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
             ),
+            _script_result(  # scoped status — changes present
+                ["git", "status", "--porcelain", "--", "_data/esg_news.json",
+                 "assets/feeds/esg_news.atom"],
+                stdout=" M _data/esg_news.json\n",
+            ),
+            _script_result(["npx", "prettier", "--write", "_data/esg_news.json"]),
+            _script_result(["git", "add", "_data/esg_news.json",
+                            "assets/feeds/esg_news.atom"]),
             _script_result(["git", "commit"]),
             _script_result(["git", "push"]),
         ]
@@ -649,79 +782,228 @@ class TestCommitAndPushGuards:
 
         assert result["git_success"] is True
         assert result["branch"] == "main"
+        assert result["current_branch"] == "main"
+        assert result["expected_branch"] == "main"
 
         push_call = mock_run_script.call_args_list[-1]
-        push_command = push_call.args[0] if push_call.args else push_call.kwargs["command"]
-        assert push_command == ["git", "push", "origin", "HEAD:main"]
+        assert push_call.args[0] == ["git", "push", "origin", "HEAD:main"]
 
-    @patch("src.agent.workflows.website_export.agent_settings")
     @patch("src.agent.workflows.website_export.run_script")
-    def test_skips_when_pull_pulled_in_pending_changes(
-        self, mock_run_script, mock_settings, passing_context, tmp_path
+    def test_all_git_calls_pin_dry_run_false(
+        self, mock_run_script, mock_website_settings, passing_context
     ):
-        """If FF pull leaves the working tree clean, treat as no-op (not failure)."""
+        """Every run_script call inside commit_and_push must pass dry_run=False
+        to prevent AGENT_DRY_RUN=true env from injecting --dry-run into git."""
         from src.agent.workflows.website_export import commit_and_push
-
-        mock_settings.website_repo_path = tmp_path
 
         mock_run_script.side_effect = [
             _script_result(
                 ["git", "symbolic-ref", "--short", "HEAD"], stdout="main\n"
             ),
-            _script_result(["git", "pull", "--ff-only", "origin", "main"]),
-            _script_result(["git", "status", "--porcelain"], stdout=""),
+            _script_result(
+                ["git", "status", "--porcelain", "--", "_data/esg_news.json",
+                 "assets/feeds/esg_news.atom"],
+                stdout=" M _data/esg_news.json\n",
+            ),
+            _script_result(["npx", "prettier"]),
+            _script_result(["git", "add"]),
+            _script_result(["git", "commit"]),
+            _script_result(["git", "push"]),
         ]
 
-        result = commit_and_push(MagicMock(), passing_context)
+        commit_and_push(MagicMock(), passing_context)
 
-        assert result["git_skipped"] is True
-        assert result["reason"] == "no_changes"
+        for call in mock_run_script.call_args_list:
+            assert call.kwargs.get("dry_run") is False, (
+                f"run_script call {call.args[0]!r} omitted dry_run=False"
+            )
 
 
-class TestSendErrorNotificationGuards:
-    """Tests that the new git error types render user-facing messages."""
+class TestSendErrorNotification:
+    """Tests for send_error_notification: aggregation, formatting, and raise."""
 
     @patch("src.agent.workflows.website_export.NotificationManager")
-    def test_wrong_branch_error_mentions_worktree(self, mock_manager_cls):
+    def test_silent_success_when_no_errors(self, mock_manager_cls):
         from src.agent.workflows.website_export import send_error_notification
 
-        mock_manager = MagicMock()
-        mock_manager.send.return_value = {"email": True}
-        mock_manager_cls.return_value = mock_manager
+        result = send_error_notification(
+            MagicMock(), {"export_success": True, "validation_passed": True}
+        )
+
+        assert result == {"notification_sent": False, "reason": "no_errors"}
+        mock_manager_cls.assert_not_called()
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_raises_workflow_error_on_failure(self, mock_manager_cls):
+        """Failures must raise so Workflow.run marks status FAILED, not COMPLETED."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
 
         context = {
-            "export_success": True,
-            "validation_passed": True,
             "git_success": False,
             "error": "wrong_branch",
             "current_branch": "feature/foo",
             "expected_branch": "main",
         }
 
-        result = send_error_notification(MagicMock(), context)
+        with pytest.raises(WorkflowError, match="failed with 1 error"):
+            send_error_notification(MagicMock(), context)
 
-        assert result["notification_sent"] is True
-        sent_notification = mock_manager.send.call_args.args[0]
-        assert "feature/foo" in sent_notification.message
-        assert "worktree" in sent_notification.message.lower()
+        # Notification was still dispatched before the raise.
+        mock_manager_cls.return_value.send.assert_called_once()
 
     @patch("src.agent.workflows.website_export.NotificationManager")
-    def test_ff_pull_error_mentions_divergence(self, mock_manager_cls):
-        from src.agent.workflows.website_export import send_error_notification
+    def test_wrong_branch_message_includes_branch_and_worktree_hint(
+        self, mock_manager_cls
+    ):
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
 
-        mock_manager = MagicMock()
-        mock_manager.send.return_value = {"email": True}
-        mock_manager_cls.return_value = mock_manager
+        mock_manager_cls.return_value.send.return_value = {"email": True}
+
+        context = {
+            "git_success": False,
+            "error": "wrong_branch",
+            "current_branch": "feature/foo",
+            "expected_branch": "main",
+        }
+
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
+
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        assert "feature/foo" in sent.message
+        assert "worktree" in sent.message.lower()
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_wrong_branch_notification_omits_feed_paths(self, mock_manager_cls):
+        """When the only failure is wrong_branch, feed paths shouldn't appear
+        in details — files were written locally but never pushed."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
+
+        context = {
+            "git_success": False,
+            "error": "wrong_branch",
+            "current_branch": "feature/foo",
+            "expected_branch": "main",
+            "json_output": "/tmp/esg_news.json",
+            "atom_output": "/tmp/esg_news.atom",
+        }
+
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
+
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        assert "json_output" not in sent.details
+        assert "atom_output" not in sent.details
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_pull_failure_message_does_NOT_assert_divergence(self, mock_manager_cls):
+        """The pull-failed message should enumerate likely causes (network,
+        auth, divergence, dirty tree) rather than asserting divergence."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
+
+        context = {
+            "prepare_ready": False,
+            "error": "git_pull_ff_failed",
+            "current_branch": "main",
+            "expected_branch": "main",
+            "git_stderr": "fatal: unable to access 'https://github.com/...': "
+            "Could not resolve host\n",
+        }
+
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
+
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        msg_lower = sent.message.lower()
+        assert "network failure" in msg_lower
+        assert "could not resolve host" in msg_lower
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_branch_check_failed_has_dedicated_message(self, mock_manager_cls):
+        """git_branch_check_failed must not fall through to generic else."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
+
+        context = {
+            "prepare_ready": False,
+            "error": "git_branch_check_failed",
+            "expected_branch": "main",
+            "git_stderr": "fatal: ref HEAD is not a symbolic ref\n",
+        }
+
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
+
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        assert "detached HEAD" in sent.message
+        assert "symbolic ref" in sent.message
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_scorecard_failure_triggers_notification(self, mock_manager_cls):
+        """Scorecard save failures must surface even when git push succeeded."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
 
         context = {
             "export_success": True,
             "validation_passed": True,
-            "git_success": False,
-            "error": "git_pull_ff_failed",
+            "scorecard_saved": False,
+            "error": "DB connection refused",
+            "git_success": True,
         }
 
-        result = send_error_notification(MagicMock(), context)
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
 
-        assert result["notification_sent"] is True
-        sent_notification = mock_manager.send.call_args.args[0]
-        assert "diverged" in sent_notification.message.lower()
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        assert "Scorecard snapshot save failed" in sent.message
+        assert "DB connection refused" in sent.message
+
+    @patch("src.agent.workflows.website_export.NotificationManager")
+    def test_status_failed_includes_stderr_hint(self, mock_manager_cls):
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
+
+        mock_manager_cls.return_value.send.return_value = {"email": True}
+
+        context = {
+            "git_success": False,
+            "error": "git_status_failed",
+            "current_branch": "main",
+            "expected_branch": "main",
+            "git_stderr": "fatal: Unable to create '.git/index.lock'\n",
+        }
+
+        with pytest.raises(WorkflowError):
+            send_error_notification(MagicMock(), context)
+
+        sent = mock_manager_cls.return_value.send.call_args.args[0]
+        assert "index.lock" in sent.message

--- a/tests/test_integration_extended.py
+++ b/tests/test_integration_extended.py
@@ -266,8 +266,12 @@ class TestAgentWorkflows:
         assert result["reason"] == "no_errors"
 
     def test_send_error_notification_with_errors(self, mock_workflow):
-        """Test send_error_notification when errors occurred."""
-        from src.agent.workflows.website_export import send_error_notification
+        """send_error_notification dispatches a notification and then raises
+        so the workflow base class records the run as FAILED."""
+        from src.agent.workflows.website_export import (
+            WorkflowError,
+            send_error_notification,
+        )
 
         with patch(
             "src.agent.workflows.website_export.NotificationManager"
@@ -276,16 +280,17 @@ class TestAgentWorkflows:
             mock_manager.send.return_value = {"email": True}
             MockManager.return_value = mock_manager
 
-            result = send_error_notification(
-                mock_workflow,
-                {
-                    "export_success": False,
-                    "export_error": "Test error",
-                },
-            )
+            with pytest.raises(WorkflowError):
+                send_error_notification(
+                    mock_workflow,
+                    {
+                        "export_success": False,
+                        "export_error": "Test error",
+                    },
+                )
 
-            assert result["notification_sent"] is True
-            assert len(result["errors"]) > 0
+            # Notification was still dispatched before the raise.
+            mock_manager.send.assert_called_once()
 
     def test_save_scorecard_snapshot_skipped_on_dry_run(self, mock_workflow):
         """Test save_scorecard_snapshot skips in dry run mode."""
@@ -746,8 +751,10 @@ class TestEndToEndWorkflows:
 
         step_names = [step.name for step in workflow.steps]
 
-        # Verify step order
+        # Verify step order (prepare_worktree runs first so the FF pull
+        # happens BEFORE export_feeds writes anything to the worktree).
         assert step_names == [
+            "prepare_worktree",
             "export_feeds",
             "save_scorecard_snapshot",
             "validate_export",


### PR DESCRIPTION
Closes #32.

## Summary

The `website_export` cron workflow ran `git add/commit/push` in the website repo against whatever branch happened to be checked out. When a feature branch was active for editing, daily feed commits landed on the feature branch instead of `main` — stalling GitHub Pages rebuilds until commits were manually cherry-picked across.

Two-part fix:

1. **Dedicated worktree** pinned to `main`, documented in `CLAUDE.md`. The cron points at this isolated worktree via `AGENT_WEBSITE_REPO_PATH`, so interactive feature-branch work in a sibling checkout can never derail it.
2. **Three defensive guards** in `commit_and_push()` so the workflow fails loudly if its assumption is ever violated (would have caught this bug on day one):
   - Branch assertion via `git symbolic-ref --short HEAD`
   - `git pull --ff-only origin main` before commit (no auto-merge from a cron job)
   - Explicit `git push origin HEAD:main` refspec (no reliance on upstream tracking)

Failure modes surface through the existing error-notification path with messages explaining the diagnosis.

## Test plan
- [x] `uv run pytest tests/test_agent_workflows.py` — 29 passed (6 new)
- [x] `uv run pytest` — 1192 passed, 24 skipped (no regressions)
- [x] One-time worktree setup on host (see `CLAUDE.md` → Website Feed Export → Worktree Setup)
- [x] Update `AGENT_WEBSITE_REPO_PATH` in environment file to the new worktree path
- [ ] Observe the next 7am cron run committing to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)