### PR TITLE
Migrate Sonnet 4 to Sonnet 4.6 with retrospective eval gate (#38)

### DIFF
--- a/.claude/skills/review-labels/SKILL.md
+++ b/.claude/skills/review-labels/SKILL.md
@@ -65,6 +65,34 @@ with engine.connect() as conn:
     fp_row = result.fetchone()
     print(f'FP-classifier flagged: {fp_row.fp_count} articles')
 
+    # 0. Model / prompt version breakdown (makes model migrations visible)
+    # After a model switch the window may straddle two models; this attributes
+    # any issues found below to the right model/prompt regime.
+    print('\n' + '-' * 70)
+    print('MODEL / PROMPT VERSION BREAKDOWN')
+    print('-' * 70)
+    result = conn.execute(text('''
+        SELECT COALESCE(bl.model_version, '(none)') as model_version,
+               COALESCE(bl.prompt_version, '(none)') as prompt_version,
+               COUNT(*) as labels,
+               MIN(a.labeled_at) as first_seen,
+               MAX(a.labeled_at) as last_seen
+        FROM articles a
+        JOIN brand_labels bl ON a.id = bl.article_id
+        WHERE a.labeled_at >= :since_date
+        GROUP BY bl.model_version, bl.prompt_version
+        ORDER BY last_seen DESC
+    '''), {'since_date': since_date})
+    rows = result.fetchall()
+    if rows:
+        for r in rows:
+            print(f'  {r.model_version} / {r.prompt_version}: {r.labels} labels '
+                  f'({r.first_seen:%Y-%m-%d} -> {r.last_seen:%Y-%m-%d})')
+        if len(rows) > 1:
+            print('  WARNING: window spans multiple model/prompt versions - attribute findings accordingly.')
+    else:
+        print('  No labels in this period')
+
     # 1. Brand sentiment breakdown
     print('\n' + '-' * 70)
     print('BRAND SENTIMENT BREAKDOWN')
@@ -99,6 +127,7 @@ with engine.connect() as conn:
                bl.social_sentiment as soc,
                bl.governance_sentiment as gov,
                bl.digital_sentiment as dig,
+               bl.model_version as model,
                a.url
         FROM articles a
         JOIN brand_labels bl ON a.id = bl.article_id
@@ -119,6 +148,7 @@ with engine.connect() as conn:
             if r.gov == -1: cats.append('G-')
             if r.dig == -1: cats.append('D-')
             print(f'  [{r.brand}] {\" \".join(cats)}: {r.title[:60]}...')
+            print(f'    Model: {r.model}')
             print(f'    URL: {r.url}')
     else:
         print('  No negative sentiment articles in this period')

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=your_openai_key_here
 
 # Labeling Model Configuration
-LABELING_MODEL=claude-sonnet-4-20250514
+LABELING_MODEL=claude-sonnet-4-6
 EMBEDDING_MODEL=text-embedding-3-small
 LABELING_BATCH_SIZE=10
 
@@ -108,4 +108,4 @@ WORKFLOW_RECORDING_DIR=data/workflow_recordings
 # Directory for generated skill files
 WORKFLOW_SKILLS_DIR=.claude/skills/learned
 # Model for analyzing recordings and extracting workflow steps
-WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-20250514
+WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-6

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ data/workflow_recordings/
 # and baseline JSONs contain local file paths and tool args (security).
 social/*
 !social/case-study-agentfluent.md
+
+# Model-migration eval run artifacts (harness is tracked; reports are not)
+data/evaluation/migration/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ NEWSDATA_API_KEY, DATABASE_URL, MAX_API_CALLS_PER_DAY=200, SCRAPE_DELAY_SECONDS=
 GDELT_TIMESPAN=3m, GDELT_MAX_RECORDS=250
 
 # Labeling
-ANTHROPIC_API_KEY, OPENAI_API_KEY, LABELING_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_API_KEY, OPENAI_API_KEY, LABELING_MODEL=claude-sonnet-4-6
 EMBEDDING_MODEL=text-embedding-3-small, LABELING_BATCH_SIZE=10
 
 # FP Classifier Pre-filter
@@ -330,13 +330,13 @@ AGENT_EMAIL_ENABLED=false, AGENT_EMAIL_RECIPIENT=, AGENT_EMAIL_SENDER=
 RESEND_API_KEY=  # Recommended for email (resend.com, 3000/month free)
 AGENT_LLM_ANALYSIS=true  # Enable Claude analysis of labeling results
 AGENT_LLM_ERROR_THRESHOLD=0.0  # 0.0 = always run, >0 = only if error_rate exceeds
-AGENT_LLM_MODEL=claude-sonnet-4-20250514  # Model for LLM analysis
+AGENT_LLM_MODEL=claude-sonnet-4-6  # Model for LLM analysis
 
 # Workflow Learning
 SCREENPIPE_API_URL=http://localhost:3030  # Screenpipe REST API
 WORKFLOW_RECORDING_DIR=data/workflow_recordings  # Session storage
 WORKFLOW_SKILLS_DIR=.claude/skills/learned  # Generated skills output
-WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-20250514  # Model for analysis
+WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-6  # Model for analysis
 ```
 
 ## ESG Category Structure

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -320,7 +320,7 @@ All agent settings are configured via environment variables:
 |----------|-------------|---------|
 | `AGENT_LLM_ANALYSIS` | Enable Claude analysis of labeling | `true` |
 | `AGENT_LLM_ERROR_THRESHOLD` | Error rate threshold to trigger analysis | `0.0` (always run) |
-| `AGENT_LLM_MODEL` | Model for LLM analysis | `claude-sonnet-4-20250514` |
+| `AGENT_LLM_MODEL` | Model for LLM analysis | `claude-sonnet-4-6` |
 | `ANTHROPIC_API_KEY` | API key for Claude | Required |
 
 ### Notification Settings

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -269,7 +269,7 @@ The restore command includes safety features:
 |----------|-------------|---------|
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude labeling | Required |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings | Required |
-| `LABELING_MODEL` | Claude model for labeling | `claude-sonnet-4-20250514` |
+| `LABELING_MODEL` | Claude model for labeling | `claude-sonnet-4-6` |
 | `EMBEDDING_MODEL` | OpenAI model for embeddings | `text-embedding-3-small` |
 | `LABELING_BATCH_SIZE` | Default articles per labeling batch | `10` |
 | `TARGET_CHUNK_TOKENS` | Target tokens per chunk | `500` |

--- a/docs/PROMPT_VERSIONING.md
+++ b/docs/PROMPT_VERSIONING.md
@@ -42,7 +42,7 @@ The `registry.json` file tracks all prompt versions and designates the productio
       "commit_message": "Initial prompt version",
       "description": "Original prompts with brand verification and ESG guidance",
       "model_recommendations": {
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 2000,
         "temperature": 0.0
       },
@@ -69,7 +69,7 @@ Each version directory contains a `config.json` that specifies:
     "user": ["title", "published_at", "source_name", "brands", "content"]
   },
   "model_config": {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 2000,
     "temperature": 0.0
   }
@@ -186,7 +186,7 @@ Add entry to `prompts/labeling/registry.json`:
   "commit_message": "Description of changes",
   "description": "Detailed description of this version",
   "model_recommendations": {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 2000,
     "temperature": 0.0
   },

--- a/docs/WORKFLOW_LEARNING.md
+++ b/docs/WORKFLOW_LEARNING.md
@@ -328,7 +328,7 @@ Environment variables (set in `.env`):
 | `SCREENPIPE_API_URL` | `http://localhost:3030` | Screenpipe REST API URL |
 | `WORKFLOW_RECORDING_DIR` | `data/workflow_recordings` | Session state storage |
 | `WORKFLOW_SKILLS_DIR` | `.claude/skills/learned` | Generated skills output |
-| `WORKFLOW_ANALYSIS_MODEL` | `claude-sonnet-4-20250514` | Model for Claude analysis |
+| `WORKFLOW_ANALYSIS_MODEL` | `claude-sonnet-4-6` | Model for Claude analysis |
 | `WORKFLOW_MAX_SCREEN_FRAMES` | `1000` | Max screen frames to retrieve per session |
 | `WORKFLOW_MAX_AUDIO_CHUNKS` | `500` | Max audio chunks to retrieve per session |
 

--- a/prompts/labeling/registry.json
+++ b/prompts/labeling/registry.json
@@ -1,7 +1,7 @@
 {
   "prompt_type": "esg_labeling",
   "description": "ESG classification prompts for sportswear brand news articles",
-  "production": "v1.8.0",
+  "production": "v1.9.0",
   "versions": {
     "v1.0.0": {
       "created_at": "2025-01-09T00:00:00Z",
@@ -121,6 +121,20 @@
       "description": "Strengthens user prompt instruction to omit sportswear brands that have no applicable ESG categories (all categories would be applies: false). Previously the prompt said to omit brands with 'no substantive ESG content' but Claude sometimes still included them with all-false labels. Now uses explicit CRITICAL instruction with example scenario (brand mentioned only as competitor/reference). Also adds defensive filter in save_brand_labels() to skip brands with empty label sets.",
       "model_recommendations": {
         "model": "claude-sonnet-4-20250514",
+        "max_tokens": 2000,
+        "temperature": 0.0
+      },
+      "tags": {
+        "author": "system",
+        "status": "superseded"
+      }
+    },
+    "v1.9.0": {
+      "created_at": "2026-06-15T00:00:00Z",
+      "commit_message": "Migrate labeling model to Claude Sonnet 4.6",
+      "description": "Identical prompt text to v1.8.0; updates the recommended model to claude-sonnet-4-6 following the retirement of claude-sonnet-4-20250514. Validated by a retrospective contrastive eval (issue #38): re-labeling 299 already-labeled articles with Sonnet 4.6 on the v1.8.0 prompt showed 0% newly-labeled rate (no scorecard-inflation risk), 0 parse failures, 92.4% exact sentiment agreement, and outcome disagreements dominated by 4.6 correctly rejecting brand-name-collision false positives (e.g. 'forensic vans', 'pumas in Patagonia') that Sonnet 4 mislabeled.",
+      "model_recommendations": {
+        "model": "claude-sonnet-4-6",
         "max_tokens": 2000,
         "temperature": 0.0
       },

--- a/prompts/labeling/v1.9.0/config.json
+++ b/prompts/labeling/v1.9.0/config.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1.9.0",
+  "system_prompt_file": "system_prompt.txt",
+  "user_prompt_file": "user_prompt.txt",
+  "variables": {
+    "system": ["brands"],
+    "user": ["title", "published_at", "source_name", "brands", "content"]
+  },
+  "model_config": {
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 2000,
+    "temperature": 0.0
+  }
+}

--- a/prompts/labeling/v1.9.0/system_prompt.txt
+++ b/prompts/labeling/v1.9.0/system_prompt.txt
@@ -1,0 +1,398 @@
+You are an ESG (Environmental, Social, Governance) news analyst specializing in the sportswear and outdoor apparel industry. Your task is to analyze news articles and classify them according to ESG categories for each brand mentioned.
+
+## CRITICAL: Brand Verification
+
+Before analyzing any brand, you MUST first verify that the article is actually about the SPORTSWEAR/APPAREL COMPANY, not something else with the same name.
+
+**Common false positives to watch for:**
+- **Puma**: Could be the animal (wildcat/cougar), Ford Puma (car model), or Puma Exploration (mining company)
+- **Patagonia**: Could be the geographic region in South America
+- **Columbia**: Could be the country, Columbia River, Columbia University, or Columbia Pictures
+- **North Face**: Could be a geographic term for the north side of a mountain
+- **Black Diamond**: Could be Black Diamond Corporation (power company), "black diamond" gemstone, or black diamond ski run difficulty. Note: Black Diamond Equipment (climbing/outdoor gear) IS the brand we're tracking.
+- **Mizuno**: Could be a person's surname (e.g., actress Sonoya Mizuno). Only Mizuno Corporation (Japanese sportswear company) articles about athletic gear, running shoes, or sports equipment are valid.
+- **Anta**: VERY HIGH FALSE POSITIVE RATE - carefully check context:
+  - "Anta Assembly", "Anta bypoll", "Anta constituency" = political district in Rajasthan, India (NOT sportswear)
+  - "Antalpha Platform" (NASDAQ: ANTA) = financial/crypto company (NOT the sportswear brand)
+  - Words containing "anta" as substring (e.g., "Vasundhara", "Santa", "advantage") = NOT the brand
+  - Only ANTA Sports (Chinese sportswear company) articles about shoes, apparel, athletes, or sports sponsorships are valid
+- **Vans**: VERY HIGH FALSE POSITIVE RATE - check if referring to VEHICLES:
+  - "container vans", "delivery vans", "camper vans", "police vans", "council vans" = vehicles (NOT sportswear)
+  - "electric vans", "EV vans", "van fleet", "battery-swapping vans" = electric vehicles (NOT sportswear)
+  - "cargo vans", "transit vans", "VW vans", "Ford Transit" = commercial vehicles (NOT sportswear)
+  - "ZEV mandate for vans", "CO2 legislation for cars and vans" = automotive policy (NOT sportswear)
+  - Any article about GM BrightDrop, Volkswagen ID. Buzz, electric fleets = vehicles (NOT sportswear)
+  - Only Vans (skateboarding/footwear brand) articles about shoes, apparel, skateboarding, or retail are valid
+- **Decathlon**: Check if referring to the SPORTING GOODS RETAILER:
+  - "Decathlon Capital Partners", "Decathlon Management" = investment/VC firms (NOT sportswear)
+  - Only Decathlon (French sporting goods retailer) articles about stores, products, or sports equipment are valid
+- **Li-Ning/361 Degrees/Xtep/Peak**: Chinese sportswear brands - verify it's about the apparel company
+
+**Target sportswear brands we are tracking:**
+{brands}
+
+If the article is NOT about the sportswear company, set `is_sportswear_brand: false` and explain what the brand name actually refers to.
+
+## CRITICAL: Product Reviews, Roundups, and Shopping Articles - DO NOT ASSIGN ESG CATEGORIES
+
+**This is the most important section for accurate classification.** Many articles that mention sustainability features are NOT ESG news - they are product reviews, shopping guides, or deals articles where sustainability is mentioned as a product feature, not as corporate ESG news.
+
+### Article Types That Should NOT Receive ESG Categories:
+
+**1. Product Reviews (even if they mention sustainable materials)**
+- "Patagonia Nano Puff Hoody review: A sustainable synthetic jacket that still delivers"
+- "I spent 6 months testing the Merrell Moab Speed 2s"
+- "Nike Air Zoom Pegasus 41 review: Great for daily training"
+- These are gear reviews from sources like t3.com, tomsguide.com, techradar.com, wirecutter.com, outdoorgearlab.com
+
+**2. Product Roundups and "Best Of" Lists**
+- "11 best gym bags for women that are stylish and functional"
+- "Best running shoes of 2025"
+- "Top 10 hiking boots for winter"
+- "Best sustainable sneakers to buy"
+- These aggregate multiple products; any sustainability mentions are product features, not ESG news
+
+**3. Shopping/Deals/Sales Articles**
+- "REI is blowing out tons of Patagonia gear during this year-end clearance sale"
+- "Athleta Sale Has Winter Clothes Starting at $9"
+- "Nike shoes on sale: Best deals today"
+- "Skechers reduced in sale"
+- These are shopping promotions, not corporate ESG news
+
+**4. Gift Guides and Buying Guides**
+- "Timberland just dropped an epic Gift Guide with a promo code"
+- "Holiday gift guide: Best fitness gear"
+- "What to buy the runner in your life"
+
+**5. Fashion/Sneaker Drops**
+- "A Ma Maniére Serves an Air Jordan 4 'Dark Mocha' in This Week's Best Footwear Drops"
+- "New Balance 550 releases in new colorway"
+- These are product/fashion news, not ESG news
+
+### WHY These Should Not Receive ESG Categories:
+
+When a product review says "Made with 65% recycled polyester" or "uses sustainable materials":
+- This is **product marketing copy**, not corporate ESG reporting
+- The article's PURPOSE is to review/sell the product, not report on the company's sustainability initiatives
+- There is no news event (no announcement, policy change, or initiative launch)
+- The sustainability info is incidental to the product description
+
+### The Key Question to Ask:
+
+**"Is this article NEWS about the company's ESG activities, or is it CONTENT about a product that happens to have sustainable features?"**
+
+- **Corporate ESG News** = Report on initiatives, policies, programs, commitments, controversies
+- **Product Content** = Reviews, roundups, shopping guides, deals, releases
+
+## Classification Categories
+
+**Environmental**: Climate action, carbon emissions, sustainable materials, recycling, waste management, water usage, biodiversity, renewable energy, environmental certifications, pollution reduction.
+
+**Social**: Worker rights, labor conditions, fair wages, supply chain ethics, diversity & inclusion, community engagement, health & safety, human rights, employee wellbeing.
+
+**Governance**: Corporate ethics, transparency, board structure, executive compensation, anti-corruption, regulatory compliance, stakeholder engagement, ESG reporting.
+
+**Digital Transformation**: Technology innovation, digital sustainability tools, AI/ML applications, supply chain digitization, e-commerce sustainability, data privacy.
+
+## ⚠️ CRITICAL WARNING: Environmental is NOT Product Features ⚠️
+
+**This is a common labeling error.** A product containing recycled materials is NOT Environmental ESG news unless the article is specifically about a corporate sustainability initiative.
+
+### THE RULE: Mentioning Sustainable Materials ≠ Environmental ESG
+
+A product that contains recycled polyester is NOT Environmental ESG news unless:
+- The article is ABOUT the company's sustainability INITIATIVE or PROGRAM
+- There is a NEWS EVENT (announcement, target, commitment, report)
+- The sustainability is the PRIMARY SUBJECT, not a product feature
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN ENVIRONMENTAL:
+
+| Article Type | Example | Why NOT Environmental |
+|--------------|---------|----------------------|
+| Product review | "Nike shoe review: Made with 65% recycled materials" | Product feature, not ESG news |
+| Product description | "Timberland boots use recycled plastic" | Marketing copy |
+| Shopping article | "Patagonia fleece on sale at REI" | Retail promotion |
+| Fashion collaboration | "KNWLS x Nike features TENCEL fibers" | Fashion news with material mention |
+| Technology feature | "GORE-TEX waterproof technology" | Product tech (waterproofing ≠ environmental) |
+| How-to guide | "How to break in Timberland boots" | Product guide |
+
+### SPECIFIC EXAMPLES - DO ASSIGN ENVIRONMENTAL:
+
+| Article Type | Example | Why IS Environmental |
+|--------------|---------|---------------------|
+| Corporate commitment | "Patagonia commits to 100% recycled polyester by 2025" | Sustainability target |
+| Carbon initiative | "Decathlon carbon reduction plan uses recycled packaging" | ESG program news |
+| Partnership announcement | "Allbirds partners with Circa for textile recycling" | Sustainability partnership |
+| Sustainability report | "Nike releases annual sustainability report" | ESG disclosure |
+| Environmental certification | "Adidas achieves carbon neutral certification" | ESG achievement |
+
+### THE CRITICAL TEST:
+
+**Is this article primarily about WHAT the company is DOING for the environment, or is it about a PRODUCT that happens to have environmental features?**
+
+- Corporate initiative → Environmental
+- Product with sustainable materials → NOT Environmental
+
+## ⚠️ CRITICAL WARNING: Governance is NOT Financial News ⚠️
+
+**This is the #1 labeling error.** Many articles are incorrectly labeled as "Governance" when they are actually financial/business news with NO ESG content.
+
+### DECISION TREE: Should I assign Governance?
+
+Ask yourself these questions IN ORDER:
+
+1. **Is this article primarily about stock prices, earnings, or financial metrics?**
+   - YES → **DO NOT assign Governance** (it's financial news)
+   - NO → Continue to question 2
+
+2. **Does the article discuss ethics violations, board oversight, ESG reporting, or accountability?**
+   - YES → Consider Governance
+   - NO → Continue to question 3
+
+3. **Is this about a CEO/leadership change?**
+   - Is the change due to ethics scandal, accountability failure, or board decision on governance grounds? → Governance
+   - Is it routine succession, retirement, or performance-based? → **NOT Governance**
+
+4. **Is this about a lawsuit or legal issue?**
+   - Does it involve fraud, misleading investors, ethics violations, or regulatory compliance? → Governance
+   - Is it a trademark dispute, patent case, or commercial lawsuit? → **NOT Governance**
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN GOVERNANCE:
+
+| Article Type | Example | Why NOT Governance |
+|--------------|---------|-------------------|
+| Stock price movement | "Nike Stock Tumbles 6% After Q2 Beat" | Price changes are NOT governance |
+| Earnings report | "Lululemon Q3 revenue beats expectations" | Financial performance is NOT governance |
+| Analyst opinion | "UBS says Salomon brands continue to win" | Investment analysis is NOT governance |
+| Stock purchase | "Tim Cook buys $3M in Nike shares" | Investor activity is NOT governance |
+| Stake acquisition | "Elliott takes $1B stake in Lululemon" | Investing is NOT governance (UNLESS activist campaign for board changes) |
+| Investment amount | "Summit invests $1.27M in Nike" | Institutional investment is NOT governance |
+| Executive appointment | "PUMA appoints new VP of Retail" | Routine hiring is NOT governance |
+| Financial restructuring | "PUMA secures €500m bridge loan" | Treasury operations are NOT governance |
+| Market analysis | "Nike prospects dim as China remains weak" | Business outlook is NOT governance |
+| Trading volume | "Anta sees unusual trading volume" | Market activity is NOT governance |
+| Price target | "Analysts set $150 price target for Nike" | Stock valuation is NOT governance |
+| Insider trading disclosure | "Lululemon insider trading disclosed" | Required filings are NOT governance news |
+
+### SPECIFIC EXAMPLES - DO ASSIGN GOVERNANCE:
+
+| Article Type | Example | Why IS Governance |
+|--------------|---------|-------------------|
+| Board changes | "Lululemon founder nominates 3 new directors" | Board composition = governance |
+| Proxy fight | "Chip Wilson launches proxy battle" | Shareholder activism = governance |
+| Ethics scandal | "CEO resigns amid accounting fraud" | Ethics violation = governance |
+| ESG reporting | "Nike releases ESG transparency report" | ESG disclosure = governance |
+| Shareholder lawsuit | "Adidas faces lawsuit over misleading statements" | Corporate accountability = governance |
+| Whistleblower | "Employee reports compliance violation" | Corporate oversight = governance |
+| Executive compensation | "Board approves new CEO pay structure" | Exec pay policy = governance |
+| Board independence | "Company adds independent directors" | Oversight structure = governance |
+
+### THE CRITICAL TEST:
+
+**If you removed all the stock prices, earnings numbers, and financial metrics from the article, would there still be substantive ESG content?**
+
+- YES → The article may qualify for Governance (if it's about ethics, board oversight, or ESG reporting)
+- NO → **DO NOT assign Governance** - the article is financial news, not ESG news
+
+## ⚠️ CRITICAL WARNING: Social is NOT Marketing or Sponsorship ⚠️
+
+**This is a common labeling error.** Many articles are incorrectly labeled as "Social" when they are actually marketing activities, sponsorship deals, or retail expansion.
+
+### DECISION TREE: Should I assign Social?
+
+Ask yourself these questions IN ORDER:
+
+1. **Is this about a store opening or retail expansion?**
+   - YES → **DO NOT assign Social** (it's retail/business news)
+   - NO → Continue to question 2
+
+2. **Is this about a celebrity/athlete endorsement or brand ambassador?**
+   - YES → **DO NOT assign Social** (it's marketing)
+   - NO → Continue to question 3
+
+3. **Is this about a sports sponsorship deal?**
+   - Is it JUST providing uniforms/equipment/funding? → **NOT Social**
+   - Does it include substantive youth development, community programs, or D&I initiatives? → Consider Social
+   - NO → Continue to question 4
+
+4. **Is this about a product launch or fashion collaboration?**
+   - YES → **DO NOT assign Social** (it's product marketing)
+   - NO → Continue to question 5
+
+5. **Does the article describe genuine community investment, D&I programs, or worker welfare?**
+   - YES → Assign Social
+   - NO → **DO NOT assign Social**
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN SOCIAL:
+
+| Article Type | Example | Why NOT Social |
+|--------------|---------|----------------|
+| Store opening | "Nike opens flagship store in NYC" | Retail expansion, not community investment |
+| Store opening | "Gymshark opens first US store" | Business expansion |
+| Celebrity endorsement | "Janhvi Kapoor named New Balance ambassador" | Marketing, not D&I |
+| Athlete signing | "PUMA signs F1 driver Rachel Robertson" | Sports marketing |
+| Sports sponsorship | "Adidas sponsors World Cup event" | Sponsorship deal |
+| Product launch | "Lululemon x NFL apparel collection" | Product marketing |
+| Fashion collaboration | "Kith x Adidas football collection" | Fashion/product news |
+| Music festival | "Vans Warped Tour goes global in 2026" | Brand sponsorship |
+| Marketing campaign | "Saucony launches Run Home for Holidays campaign" | Advertising |
+| Brand event | "JD Sports x Adidas rooftop event in Dallas" | Marketing event |
+
+### SPECIFIC EXAMPLES - DO ASSIGN SOCIAL:
+
+| Article Type | Example | Why IS Social |
+|--------------|---------|---------------|
+| Charitable donation | "New Balance Foundation grants $50K to nonprofit" | Community investment |
+| D&I initiative | "Under Armour Diversity Series highlights underrepresented runners" | D&I program |
+| Accessibility design | "Puma designs shoes specifically for para-athletes" | Inclusive design |
+| Employee wellbeing | "Nike employees share career advice on growth and belonging" | Workplace culture/D&I |
+| Youth development | "Diadora NIL program provides $50K to high school athletes" | Substantive community support |
+| Community program | "Nike creates free community hub in South London" | Community investment |
+| Worker rights | "Adidas releases supply chain transparency report" | Labor conditions |
+| Paralympic support | "Columbia supports wheelchair curling athletes" | Accessibility/inclusion |
+
+### THE CRITICAL TEST:
+
+**If the brand stopped this activity, would it meaningfully harm any community or group of people?**
+
+- Store closes → Customers shop elsewhere → **NOT Social**
+- Sponsorship ends → Team finds another sponsor → **NOT Social**
+- Celebrity deal ends → Celebrity endorses different brand → **NOT Social**
+- Youth program ends → Kids lose developmental opportunities → **IS Social**
+- Accessibility initiative ends → Disabled athletes lose access → **IS Social**
+- Community center closes → Neighborhood loses free resources → **IS Social**
+
+## CRITICAL: Athlete Endorsements & Sponsorships
+
+Athlete endorsement deals, signature shoe releases, and sports sponsorships are typically marketing/business activities, NOT ESG content.
+
+**Do NOT assign ESG categories to:**
+- Athlete signature shoe releases ("Reebok Angel Reese 1 releases November 14")
+- Sports team uniform reveals ("Nike Reveals 2025-26 City Edition Uniforms")
+- Athlete endorsement announcements ("New Balance announces Cooper Flagg shoe")
+- Sponsorship deal news ("Adidas sponsors World Cup event")
+- Fashion collaborations ("Madhappy x Converse Chuck 70 collab")
+
+**EXCEPTION - These MAY qualify for Social category:**
+- Olympic/Paralympic partnerships that focus on athlete development programs with substantive support
+- Sponsorships with explicit diversity, equity, and inclusion initiatives (beyond just marketing language)
+- Community investment programs beyond just product/uniform provision
+- Articles about athlete welfare, accessibility, or inclusive design
+
+## Sentiment Guidelines
+
+- **Positive (1)**: The brand is praised, making progress, exceeding standards, leading the industry, receiving awards, or taking proactive positive action.
+- **Neutral (0)**: Factual reporting, industry trends, announcements without clear positive/negative framing, balanced coverage of both sides.
+- **Negative (-1)**: Criticism, violations, failures, falling short of standards, scandals, lawsuits, negative incidents, or harm caused.
+
+## Evidence Requirements
+
+For each category label you assign, you MUST provide 1-3 direct quotes from the article that justify the classification. These quotes should be exact excerpts from the article text, not paraphrased. The quotes should clearly demonstrate why the category applies and support the sentiment you assigned.
+
+## Important Guidelines
+
+1. FIRST verify if each brand mention refers to the sportswear company or something else.
+2. Only assign ESG categories if the article is about the sportswear brand AND contains clear, relevant information.
+3. An article can have multiple categories if it covers multiple ESG topics.
+4. Different brands in the same article may have different categories and sentiments.
+5. If a brand is only briefly mentioned without substantive ESG-related content, do not assign categories for that brand.
+6. Your confidence score should reflect how certain you are about ALL classifications for that brand (0.0-1.0).
+
+## CRITICAL: Understanding is_sportswear_brand
+
+The `is_sportswear_brand` field indicates whether the article contains **substantive content** about the sportswear/apparel company. This determines whether the article is worth processing for potential ESG content or future analysis.
+
+**Set `is_sportswear_brand: false` when:**
+
+1. **Brand name refers to something ELSE entirely:**
+   - Puma the animal (not Puma sportswear)
+   - Patagonia the geographic region (not Patagonia outdoor apparel)
+   - "Vans" meaning vehicles (not Vans footwear)
+   - Puma Biotechnology, Columbia University (different entities)
+   - Sonoya Mizuno the actress (not Mizuno sportswear)
+
+2. **Financial articles with NO substantive commentary (this is a major error source):**
+
+   **Auto-generated institutional holdings articles** → `is_sportswear_brand: false`
+   These are template articles about hedge funds, pension funds, or advisory firms buying/selling shares. They contain only SEC filing data, share counts, and boilerplate financial metrics. Even though the sportswear brand name appears prominently (often in the title), there is ZERO substantive content about the brand's business.
+   - "Midwest Trust Co Invests $1.64 Million in NIKE, Inc." — just 13F filing data
+   - "Vontobel Holding Ltd. Boosts Position in Under Armour" — just share counts and moving averages
+   - "Thrivent Financial Has $26.71 Million Stake in Columbia Sportswear" — just portfolio disclosure
+   - "Park Place Capital Corp Boosts Holdings in lululemon" — just SEC filing data
+   - "OFI Invest Asset Management Buys 8,671 Shares of Deckers Outdoor" — just share purchase data
+
+   **Telltale signs of template stock articles** (almost always `is_sportswear_brand: false`):
+   - Phrases like "Get Free Report", "according to its most recent 13F filing"
+   - "The stock has a 200-day moving average of $X" / "50-day moving average"
+   - "Several other research analysts also recently issued reports"
+   - "shares of the footwear maker" / "shares of the textile maker" / "shares of the apparel retailer"
+   - Sources like MarketBeat, MarketScreener, HoldingsChannel, tickerreport.com, themarketsdaily.com
+
+   **Pure stock price/volume articles** → `is_sportswear_brand: false`
+   - "NKE stock up 4% today" — just price movement
+   - "Adidas (OTCMKTS:ADDYY) Sees Strong Trading Volume" — just volume data
+   - "Allbirds Stock Price Up 1.5% – What Next?" — price + boilerplate company profile
+   - "PUMA SE trading above 50-day moving average" — technical analysis only
+   - "Anta Sports Products Sees Unusually-High Trading Volume" — just volume spike data
+
+   **Short interest articles** → `is_sportswear_brand: false`
+   - "Short Interest in Adidas AG Rises By 88.3%" — just short interest numbers
+   - "Deckers Outdoor Sees Significant Decline in Short Interest" — just share counts
+
+   **Boilerplate analyst rating roundups** → `is_sportswear_brand: false`
+   These list analyst ratings/price targets WITHOUT explaining the reasoning behind them. They are just aggregated data:
+   - "Columbia Sportswear Receives Consensus Rating of 'Hold' from Analysts" — just a list of ratings
+   - "lululemon athletica Receives $227.15 Consensus PT from Analysts" — just averaged price targets
+   - "Columbia Sportswear Lowered to Sell Rating by Wall Street Zen" — rating change + boilerplate, no reasoning
+   - "Analysts Set Columbia Sportswear PT at $60.50" — just price target numbers
+   - "lululemon athletica 'Market Perform' Rating Reiterated at Telsey Advisory" — rating + no analysis
+
+   **Boilerplate stock comparison articles** → `is_sportswear_brand: false`
+   Side-by-side financial metric comparisons with no editorial analysis:
+   - "Reviewing Victoria's Secret & Allbirds" — just P/E, revenue, margins tables
+   - "Oxford Industries vs. Under Armour Head to Head Comparison" — just financial ratios
+   - "Comparing Hennes & Mauritz and 361 Degrees International" — just metric comparisons
+
+   **Auto-generated stock return calculators** → `is_sportswear_brand: false`
+   - "$100 Invested In Deckers Outdoor 20 Years Ago Would Be Worth This Much Today" — just math
+
+   **Shopping/deals/product promotion articles** → `is_sportswear_brand: false`
+   These are about buying products, not about the brand's business:
+   - "Skechers slippers 'perfect for cold months' reduced to £19" — product deal
+   - "Patagonia just added new gear to its New Arrivals section" — shopping guide
+   - "Converse Chuck Taylor heart sneakers at DSW for Valentine's Day" — product promotion
+   - "Brooks Running shoes: Adrenaline GTS 24 now $20 off" — sale listing
+   - "lululemon 'We Made Too Much' Section February 2026" — sale section roundup
+
+3. **Tangential mentions without substantive coverage:**
+   - Former executives now at other companies (article is about the OTHER company)
+   - Brand mentioned only as biographical context or comparison
+   - Industry reports where brand appears in a list without detail
+
+4. **Brand mentioned only as comparison, analogy, or reference point:**
+   - Color comparisons: "reminiscent of Nike's Infrared orange", "similar to Adidas' classic blue"
+   - Style comparisons: "gives off Patagonia vibes", "looks like something from Lululemon"
+   - Quality/reputation references: "built to Nike standards", "Adidas-level durability"
+   - Historical references: "back when Nike was just starting out"
+   - Aspiration analogies: "wants to be the Patagonia of baby clothes"
+   - The article's SUBJECT is something else; the brand is merely a point of reference
+
+**Set `is_sportswear_brand: true` (or omit the brand) when the article HAS substantive content:**
+
+- Product announcements, reviews, sales (→ true, but no ESG categories apply)
+- Store openings, sponsorships, athlete signings (→ true, but no ESG categories apply)
+- Financial articles **with substantive business commentary or analysis**:
+  - "Jim Cramer says Nike CEO is reinventing the company" → true (discusses strategy/management)
+  - "Analysts give Adidas Buy rating citing strong Q4 outlook" → true (discusses business prospects with reasoning)
+  - "Puma reports earnings beat driven by China growth" → true (discusses business performance with context)
+  - "Sinking 48%, Is Lululemon a Buying Opportunity?" → true (contains actual investment thesis with business analysis)
+  - "Nike Road to Recovery: Innovation, Competition, and Steady Dividend Growth" → true (discusses strategy)
+  - "Needham downgrades Nike citing brand weakness in North America" → true (analyst gives specific reasoning)
+  - "Deckers Racks Up Record Revenue as Significant Global Demand for Ugg and Hoka Continues" → true (discusses business performance with CEO quotes and segment analysis)
+
+**Key test for financial articles:** Would this article be useful if we added a "Finance" or "Business News" category?
+
+- **YES → `is_sportswear_brand: true`** if it contains: analyst reasoning, CEO/CFO quotes, business strategy discussion, competitive analysis, earnings with commentary on what drove results, investment thesis with company-specific analysis
+- **NO → `is_sportswear_brand: false`** if it contains only: raw stock price data, 13F filing share counts, moving averages, boilerplate analyst rating lists without reasoning, short interest numbers, template financial comparisons, auto-generated "X invested Y years ago" calculators
+
+**The critical distinction:** Does the article contain **human-written analysis or commentary** about the brand's business? Or is it **auto-generated/template content** that just plugs financial data into a standard format? Template content = false positive.

--- a/prompts/labeling/v1.9.0/user_prompt.txt
+++ b/prompts/labeling/v1.9.0/user_prompt.txt
@@ -1,0 +1,69 @@
+Analyze this news article for ESG classifications for each brand mentioned.
+
+**Article Title**: {title}
+**Publication Date**: {published_at}
+**Source**: {source_name}
+**Brands to Analyze**: {brands}
+
+**Article Content**:
+{content}
+
+---
+
+For each brand mentioned, FIRST verify if it refers to the sportswear/apparel company. Then provide ESG analysis only for confirmed sportswear brands with substantive content.
+
+Respond in the following JSON format:
+
+```json
+{{
+  "brand_analyses": [
+    {{
+      "brand": "Brand Name",
+      "is_sportswear_brand": true,
+      "not_sportswear_reason": null,
+      "categories": {{
+        "environmental": {{
+          "applies": true,
+          "sentiment": 1,
+          "evidence": ["Direct quote from article...", "Another supporting quote..."]
+        }},
+        "social": {{
+          "applies": false,
+          "sentiment": null,
+          "evidence": []
+        }},
+        "governance": {{
+          "applies": true,
+          "sentiment": 0,
+          "evidence": ["Direct quote..."]
+        }},
+        "digital_transformation": {{
+          "applies": false,
+          "sentiment": null,
+          "evidence": []
+        }}
+      }},
+      "confidence": 0.85,
+      "reasoning": "Brief explanation of why these classifications were assigned"
+    }},
+    {{
+      "brand": "Puma",
+      "is_sportswear_brand": false,
+      "not_sportswear_reason": "Article is about puma (wildcat/mountain lion), not Puma sportswear",
+      "categories": {{}},
+      "confidence": 0.95,
+      "reasoning": "Brand name refers to the animal, not the sportswear company"
+    }}
+  ],
+  "article_summary": "1-2 sentence summary of the article's main themes"
+}}
+```
+
+Important reminders:
+- FIRST check if each brand refers to the sportswear company or something else (animal, region, car, etc.)
+- If NOT a sportswear brand: set `is_sportswear_brand: false`, explain in `not_sportswear_reason`, leave `categories` empty
+- If IS a sportswear brand: set `is_sportswear_brand: true`, `not_sportswear_reason: null`, fill in categories
+- Only set `applies: true` if the article contains clear, relevant ESG information for that category
+- Sentiment must be -1, 0, or 1 when applies is true; null when applies is false
+- Evidence quotes MUST be exact text from the article
+- **CRITICAL: If a sportswear brand has NO applicable ESG categories (all categories would be applies: false), DO NOT include that brand in brand_analyses at all.** Only include brands that have at least one category with applies: true. A brand mentioned only as a competitor, reference point, or context (e.g., "Nike's biggest Chinese challenger") should be omitted entirely if it has no ESG content of its own.

--- a/scripts/eval_model_migration.py
+++ b/scripts/eval_model_migration.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Retrospective model-migration evaluation harness.
+
+Re-labels a stratified sample of already-labeled articles with a candidate
+model and diffs the result against the stored baseline labels, to gate a model
+migration (Sonnet 4 -> 4.6) before flipping production defaults.
+
+Why retrospective: the outgoing model has been retired, so a live A/B is
+impossible. The stored labels are the only record of the old model's behavior.
+
+Methodology guards (see issue #38):
+  * Scope to ONE production regime -- baseline labels produced by the
+    --baseline-model under --prompt-version -- and re-label with that same
+    prompt, so the diff isolates the MODEL change (not prompt drift) and
+    matches what production will actually run post-flip.
+  * The baseline must reflect a genuine LLM decision. We exclude articles whose
+    false_positive status came from the FP classifier pre-filter
+    (classifier_predictions.action_taken == 'skipped_llm') or from
+    deduplication, and we route human-reviewed labels into a separate anchor
+    stratum.
+  * A 'pending' (never-labeled) stratum has no baseline; it is re-labeled and
+    emitted for human-only adjudication, to catch the candidate newly ACCEPTING
+    junk/financial articles that never entered the labeled pool.
+
+The numeric verdict is an advisory noise-screen. The real gate is human
+adjudication of the disagreement and pending tables in the markdown report.
+
+Usage:
+    # Validate sampling + estimate cost without spending API tokens:
+    uv run python scripts/eval_model_migration.py --dry-run
+
+    # Run the eval against Sonnet 4.6:
+    uv run python scripts/eval_model_migration.py \
+        --candidate-model claude-sonnet-4-6 --sample-size 300
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import random
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+# Add project root to path (matches the other scripts/ entry points).
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.data_collection.database import db
+from src.data_collection.models import Article, BrandLabel, ClassifierPrediction
+from src.labeling.labeler import ArticleLabeler
+from src.migration_eval.compare import build_verdict, compare_article, decisions_from_response
+from src.migration_eval.models import CATEGORIES, ArticleComparison, BrandDecision, Thresholds
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("eval_model_migration")
+
+# Default outgoing/baseline regime.
+DEFAULT_BASELINE_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_CANDIDATE_MODEL = "claude-sonnet-4-6"
+DEFAULT_PROMPT_VERSION = "v1.8.0"
+
+OUTPUT_DIR = Path("data/evaluation/migration")
+
+
+# --------------------------------------------------------------------------- #
+# Sampling
+# --------------------------------------------------------------------------- #
+
+
+def _content_for(article: Article) -> str | None:
+    return article.full_content or article.description
+
+
+def _sample_ids(ids: list[UUID], n: int, rng: random.Random) -> list[UUID]:
+    if n <= 0:
+        return []
+    if len(ids) <= n:
+        return list(ids)
+    return rng.sample(ids, n)
+
+
+def sample_strata(
+    session,
+    *,
+    baseline_model: str,
+    prompt_version: str,
+    n_labeled: int,
+    n_false_positive: int,
+    n_pending: int,
+    n_anchor_cap: int,
+    rng: random.Random,
+) -> dict[str, list[UUID]]:
+    """Return article ids per stratum, applying the methodology guards."""
+    # Articles excluded from the false-positive baseline: status set by the FP
+    # classifier rather than the LLM.
+    fp_skipped = {
+        row[0]
+        for row in session.query(ClassifierPrediction.article_id)
+        .filter(
+            ClassifierPrediction.classifier_type == "fp",
+            ClassifierPrediction.action_taken == "skipped_llm",
+        )
+        .all()
+    }
+
+    # Articles whose labels include a human review -> anchor stratum.
+    human_article_ids = {
+        row[0]
+        for row in session.query(BrandLabel.article_id)
+        .filter(BrandLabel.human_reviewed.is_(True))
+        .all()
+    }
+
+    # labeled stratum: model+prompt match, no human review.
+    labeled_ids = [
+        row[0]
+        for row in session.query(BrandLabel.article_id)
+        .join(Article, Article.id == BrandLabel.article_id)
+        .filter(
+            Article.labeling_status == "labeled",
+            BrandLabel.model_version == baseline_model,
+            BrandLabel.prompt_version == prompt_version,
+        )
+        .distinct()
+        .all()
+        if row[0] not in human_article_ids
+    ]
+
+    # false_positive stratum: genuine LLM-decided false positives.
+    # We exclude FP-classifier pre-filter skips (no LLM call) so the baseline is
+    # a real model decision. We do NOT date-scope these: false_positive status
+    # records no timestamp, and most in-window FPs are now caught by the FP
+    # classifier, leaving too few LLM FPs in the v1.8.0 window. The baseline FP
+    # set therefore spans prompt versions, but the confound is conservative —
+    # older prompts were *looser* on false positives, so a baseline FP is, if
+    # anything, even more likely to be FP under the stricter v1.8.0; a flip to
+    # "labeled" remains a genuine signal worth human review.
+    fp_ids = [
+        row[0]
+        for row in session.query(Article.id)
+        .filter(Article.labeling_status == "false_positive")
+        .all()
+        if row[0] not in fp_skipped
+    ]
+
+    # pending stratum: never labeled, has content + brands to analyze.
+    pending_ids = [
+        a.id
+        for a in session.query(Article)
+        .filter(Article.labeling_status == "pending")
+        .all()
+        if _content_for(a) and a.brands_mentioned
+    ]
+
+    anchor_ids = list(human_article_ids)
+
+    return {
+        "labeled": _sample_ids(labeled_ids, n_labeled, rng),
+        "false_positive": _sample_ids(fp_ids, n_false_positive, rng),
+        "anchor": _sample_ids(anchor_ids, n_anchor_cap, rng),
+        "pending": _sample_ids(pending_ids, n_pending, rng),
+    }
+
+
+def baseline_decisions_for(session, article_id: UUID, baseline_model: str) -> dict[str, BrandDecision]:
+    """Reconstruct effective baseline decisions from stored brand_labels rows."""
+    rows = (
+        session.query(BrandLabel)
+        .filter(BrandLabel.article_id == article_id)
+        .all()
+    )
+    decisions: dict[str, BrandDecision] = {}
+    for bl in rows:
+        applies = {
+            "environmental": bool(bl.environmental),
+            "social": bool(bl.social),
+            "governance": bool(bl.governance),
+            "digital_transformation": bool(bl.digital_transformation),
+        }
+        sentiment = {
+            "environmental": bl.environmental_sentiment,
+            "social": bl.social_sentiment,
+            "governance": bl.governance_sentiment,
+            "digital_transformation": bl.digital_sentiment,
+        }
+        # Mirror save filter: a stored row always has >=1 applicable category,
+        # but guard anyway for safety.
+        if any(applies.values()):
+            decisions[bl.brand.lower()] = BrandDecision(
+                brand=bl.brand,
+                applies=applies,
+                sentiment=sentiment,
+                confidence=bl.confidence_score or 0.0,
+                reasoning=bl.reasoning or "",
+            )
+    return decisions
+
+
+# --------------------------------------------------------------------------- #
+# Re-labeling
+# --------------------------------------------------------------------------- #
+
+
+def relabel_article(labeler: ArticleLabeler, article: dict) -> tuple[ArticleComparison | None, dict]:
+    """Run the candidate model on one article; return (comparison-inputs, meta).
+
+    Returns the candidate decisions + parse status + reasoning + timing so the
+    caller can build the ArticleComparison (which also needs the baseline).
+    """
+    content = article["content"]
+    t0 = time.monotonic()
+    result = labeler.label_article(
+        title=article["title"],
+        content=content,
+        brands=article["brands_mentioned"],
+        published_at=article["published_at"],
+        source_name=article["source_name"],
+    )
+    latency = time.monotonic() - t0
+
+    if not result.success or result.response is None:
+        return None, {
+            "parse_ok": False,
+            "error": result.error or "labeling failed",
+            "latency": latency,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "candidate_decisions": {},
+            "candidate_reasoning": "",
+        }
+
+    decisions = decisions_from_response(result.response)
+    return None, {
+        "parse_ok": True,
+        "error": None,
+        "latency": latency,
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
+        "candidate_decisions": decisions,
+        "candidate_reasoning": result.response.article_summary,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def _comparison_to_dict(c: ArticleComparison) -> dict:
+    return dataclasses.asdict(c)
+
+
+def write_reports(
+    output_dir: Path,
+    *,
+    args: argparse.Namespace,
+    verdict,
+    comparisons: list[ArticleComparison],
+    pending: list[dict],
+    timestamp: str,
+) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / f"migration_eval_{timestamp}.json"
+    md_path = output_dir / f"migration_eval_{timestamp}.md"
+
+    payload = {
+        "generated_at": timestamp,
+        "config": {
+            "baseline_model": args.baseline_model,
+            "candidate_model": args.candidate_model,
+            "prompt_version": args.prompt_version,
+            "seed": args.seed,
+        },
+        "verdict": dataclasses.asdict(verdict),
+        "comparisons": [_comparison_to_dict(c) for c in comparisons],
+        "pending_review": pending,
+    }
+    json_path.write_text(json.dumps(payload, indent=2, default=str))
+
+    md_path.write_text(_render_markdown(args, verdict, comparisons, pending, timestamp))
+    return json_path, md_path
+
+
+def _render_markdown(args, verdict, comparisons, pending, timestamp) -> str:
+    v = verdict
+    lines: list[str] = []
+    lines.append(f"# Model Migration Eval — {args.candidate_model}")
+    lines.append("")
+    lines.append(f"_Generated {timestamp}_")
+    lines.append("")
+    lines.append(
+        f"Baseline `{args.baseline_model}` vs candidate `{args.candidate_model}`, "
+        f"both on prompt `{args.prompt_version}`."
+    )
+    lines.append("")
+
+    # Verdict banner.
+    if v.hard_fail:
+        banner = "🛑 **HARD FAIL** — integration broke; do not promote."
+    elif v.passed_advisory:
+        banner = "✅ **Advisory thresholds passed** — still requires human sign-off below."
+    else:
+        banner = "⚠️ **Flags raised** — investigate before promoting."
+    lines.append(f"## Verdict: {banner}")
+    lines.append("")
+    lines.append(
+        "> The numeric verdict is an advisory noise-screen. A clean diff only proves the "
+        "candidate *mimics* the old model (including its known failure modes). **The gate is "
+        "human review of the Disagreements and Pending tables below.**"
+    )
+    lines.append("")
+    if v.flags:
+        lines.append("**Flags:**")
+        for f in v.flags:
+            lines.append(f"- {f}")
+        lines.append("")
+
+    # Summary metrics.
+    c = v.outcome_confusion
+    lines.append("## Summary metrics")
+    lines.append("")
+    lines.append(f"- Articles compared: **{v.n_compared}** (parse failures: {v.n_parse_failures})")
+    lines.append(f"- Outcome disagreement rate: **{v.outcome_disagreement_rate:.1%}**")
+    lines.append(
+        f"- Newly-labeled rate (baseline FP → candidate labeled, *scorecard-inflation risk*): "
+        f"**{v.newly_labeled_rate:.1%}**"
+    )
+    lines.append(f"- Dropped-label rate (baseline labeled → candidate FP): **{v.dropped_label_rate:.1%}**")
+    lines.append(f"- Category macro-F1 (candidate vs baseline reference): **{v.category_f1_macro:.3f}**")
+    lines.append(
+        f"- Sentiment agreement: exact **{v.sentiment_exact_rate:.1%}**, "
+        f"within ±1 **{v.sentiment_within1_rate:.1%}**"
+    )
+    lines.append(
+        f"- Human-anchor disagreements: **{v.n_human_anchor_disagreements}/{v.n_human_anchors}** "
+        f"(closer-to-truth subset)"
+    )
+    lines.append(
+        f"- Tokens: {v.total_input_tokens:,} in / {v.total_output_tokens:,} out · "
+        f"est. cost **${v.estimated_cost_usd:.2f}** · mean latency {v.mean_latency_s:.2f}s"
+    )
+    lines.append("")
+    lines.append("### Outcome confusion")
+    lines.append("")
+    lines.append("| baseline ↓ / candidate → | labeled | false_positive |")
+    lines.append("|---|---|---|")
+    lines.append(f"| **labeled** | {c['ll']} | {c['lf']} |")
+    lines.append(f"| **false_positive** | {c['fl']} | {c['ff']} |")
+    lines.append("")
+    lines.append("### Per-category agreement")
+    lines.append("")
+    lines.append("| category | precision | recall | F1 | TP | FP | FN |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for cat in CATEGORIES:
+        m = v.category_metrics[cat]
+        lines.append(
+            f"| {cat} | {m['precision']:.3f} | {m['recall']:.3f} | {m['f1']:.3f} | "
+            f"{int(m['tp'])} | {int(m['fp'])} | {int(m['fn'])} |"
+        )
+    lines.append("")
+
+    # Disagreement table.
+    disagreements = [c for c in comparisons if c.has_disagreement]
+    lines.append(f"## Disagreements to review ({len(disagreements)})")
+    lines.append("")
+    if not disagreements:
+        lines.append("_None._")
+    for comp in disagreements:
+        anchor = " · 🔬 human-anchor" if comp.is_human_anchor else ""
+        if not comp.parse_ok:
+            lines.append(f"### ❌ {comp.title}{anchor}")
+            lines.append(f"- **Parse failure:** {comp.error}")
+            lines.append("")
+            continue
+        flip = "" if comp.outcome_match else f" — **OUTCOME FLIP: {comp.baseline_outcome} → {comp.candidate_outcome}**"
+        lines.append(f"### {comp.title}{anchor}{flip}")
+        for bc in comp.brand_comparisons:
+            if bc.status != "shared":
+                lines.append(f"- **{bc.brand}**: {bc.status}")
+                continue
+            cat_changes = []
+            for d in bc.category_diffs:
+                if not d.applies_match:
+                    cat_changes.append(
+                        f"{d.category}: applies {d.baseline_applies}→{d.candidate_applies}"
+                    )
+                elif d.baseline_applies and not d.sentiment_match:
+                    cat_changes.append(
+                        f"{d.category}: sentiment {d.baseline_sentiment}→{d.candidate_sentiment}"
+                    )
+            if cat_changes:
+                lines.append(f"- **{bc.brand}**: " + "; ".join(cat_changes))
+        if comp.candidate_reasoning:
+            lines.append(f"  - _candidate summary:_ {comp.candidate_reasoning}")
+        lines.append("")
+
+    # Pending (human-only) stratum.
+    lines.append(f"## Pending articles — candidate raw output ({len(pending)})")
+    lines.append("")
+    lines.append(
+        "_No baseline exists for these (never labeled). Review whether the candidate "
+        "correctly REJECTS junk/financial articles vs newly accepting them._"
+    )
+    lines.append("")
+    for p in pending:
+        outcome = p["candidate_outcome"]
+        brands = ", ".join(p["candidate_brands"]) if p["candidate_brands"] else "—"
+        flag = "⚠️ ACCEPTED" if outcome == "labeled" else "rejected"
+        lines.append(f"- [{flag}] **{p['title']}** → brands: {brands}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--candidate-model", default=DEFAULT_CANDIDATE_MODEL)
+    p.add_argument("--baseline-model", default=DEFAULT_BASELINE_MODEL)
+    p.add_argument("--prompt-version", default=DEFAULT_PROMPT_VERSION)
+    p.add_argument("--sample-size", type=int, default=300, help="Total comparable budget (labeled+FP)")
+    p.add_argument("--labeled-frac", type=float, default=0.55, help="Fraction of comparable budget for labeled stratum")
+    p.add_argument("--pending", type=int, default=40, help="Pending (human-only) stratum size")
+    p.add_argument("--anchor-cap", type=int, default=40, help="Max human-reviewed anchor articles")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--output-dir", default=str(OUTPUT_DIR))
+    p.add_argument("--dry-run", action="store_true", help="Sample + estimate only; no API calls")
+    # Threshold overrides.
+    p.add_argument("--max-outcome-disagreement", type=float, default=0.10)
+    p.add_argument("--max-newly-labeled-rate", type=float, default=0.10)
+    p.add_argument("--min-category-f1", type=float, default=0.85)
+    p.add_argument("--min-sentiment-exact", type=float, default=0.80)
+    return p.parse_args()
+
+
+def _load_article_payloads(session, ids: list[UUID]) -> list[dict]:
+    payloads = []
+    for a in session.query(Article).filter(Article.id.in_(ids)).all():
+        content = _content_for(a)
+        if not content or not a.brands_mentioned:
+            continue
+        payloads.append(
+            {
+                "id": a.id,
+                "title": a.title,
+                "content": content,
+                "brands_mentioned": list(a.brands_mentioned),
+                "published_at": a.published_at,
+                "source_name": a.source_name,
+            }
+        )
+    return payloads
+
+
+def main() -> int:
+    args = parse_args()
+    rng = random.Random(args.seed)
+    db.init_db()
+
+    n_labeled = int(args.sample_size * args.labeled_frac)
+    n_fp = args.sample_size - n_labeled
+
+    with db.get_session() as session:
+        strata = sample_strata(
+            session,
+            baseline_model=args.baseline_model,
+            prompt_version=args.prompt_version,
+            n_labeled=n_labeled,
+            n_false_positive=n_fp,
+            n_pending=args.pending,
+            n_anchor_cap=args.anchor_cap,
+            rng=rng,
+        )
+
+        logger.info("Sampled strata:")
+        for name, ids in strata.items():
+            logger.info("  %-15s %d articles", name, len(ids))
+
+        # Build payloads + baselines while the session is open.
+        comparable_ids = strata["labeled"] + strata["false_positive"] + strata["anchor"]
+        payloads = {p["id"]: p for p in _load_article_payloads(session, comparable_ids)}
+        pending_payloads = _load_article_payloads(session, strata["pending"])
+        anchor_set = set(strata["anchor"])
+        baselines = {
+            aid: baseline_decisions_for(session, aid, args.baseline_model)
+            for aid in payloads
+        }
+
+    n_comparable = len(payloads)
+    n_pending = len(pending_payloads)
+    if args.dry_run:
+        # ~ rough token estimate: 3k in / 0.8k out per article.
+        est_articles = n_comparable + n_pending
+        est_cost = est_articles * (3000 / 1e6 * 3.0 + 800 / 1e6 * 15.0)
+        logger.info(
+            "DRY RUN: would label %d comparable + %d pending = %d articles (~$%.2f). No API calls made.",
+            n_comparable, n_pending, est_articles, est_cost,
+        )
+        return 0
+
+    labeler = ArticleLabeler(model=args.candidate_model, prompt_version=args.prompt_version)
+    logger.info("Re-labeling %d comparable articles with %s …", n_comparable, args.candidate_model)
+
+    comparisons: list[ArticleComparison] = []
+    latencies: list[float] = []
+    for i, (aid, payload) in enumerate(payloads.items(), 1):
+        _, meta = relabel_article(labeler, payload)
+        latencies.append(meta["latency"])
+        comparisons.append(
+            compare_article(
+                str(aid),
+                payload["title"],
+                baselines[aid],
+                meta["candidate_decisions"],
+                baseline_reasoning="",
+                candidate_reasoning=meta["candidate_reasoning"],
+                is_human_anchor=aid in anchor_set,
+                parse_ok=meta["parse_ok"],
+                error=meta["error"],
+            )
+        )
+        if i % 25 == 0:
+            logger.info("  %d/%d", i, n_comparable)
+
+    # Pending (human-only) stratum.
+    pending_results: list[dict] = []
+    logger.info("Re-labeling %d pending articles (human-only review) …", n_pending)
+    for payload in pending_payloads:
+        _, meta = relabel_article(labeler, payload)
+        latencies.append(meta["latency"])
+        decisions = meta["candidate_decisions"]
+        pending_results.append(
+            {
+                "article_id": str(payload["id"]),
+                "title": payload["title"],
+                "candidate_outcome": "labeled" if decisions else "false_positive",
+                "candidate_brands": [d.brand for d in decisions.values()],
+                "parse_ok": meta["parse_ok"],
+            }
+        )
+
+    stats = labeler.get_stats()
+    verdict = build_verdict(
+        comparisons,
+        Thresholds(
+            max_outcome_disagreement=args.max_outcome_disagreement,
+            max_newly_labeled_rate=args.max_newly_labeled_rate,
+            min_category_f1=args.min_category_f1,
+            min_sentiment_exact=args.min_sentiment_exact,
+        ),
+        total_input_tokens=int(stats["total_input_tokens"]),
+        total_output_tokens=int(stats["total_output_tokens"]),
+        estimated_cost_usd=float(stats["estimated_cost_usd"]),
+        mean_latency_s=(sum(latencies) / len(latencies) if latencies else 0.0),
+    )
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path, md_path = write_reports(
+        Path(args.output_dir),
+        args=args,
+        verdict=verdict,
+        comparisons=comparisons,
+        pending=pending_results,
+        timestamp=timestamp,
+    )
+
+    logger.info("=" * 60)
+    logger.info("Verdict: %s", "HARD FAIL" if verdict.hard_fail else ("PASS (advisory)" if verdict.passed_advisory else "FLAGS RAISED"))
+    for f in verdict.flags:
+        logger.info("  %s", f)
+    logger.info(
+        "Outcome disagreement: %.1f%%  newly-labeled: %.1f%%  cat-F1: %.3f",
+        verdict.outcome_disagreement_rate * 100,
+        verdict.newly_labeled_rate * 100,
+        verdict.category_f1_macro,
+    )
+    logger.info("Reports:\n  %s\n  %s", json_path, md_path)
+    logger.info("=" * 60)
+    return 1 if verdict.hard_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -45,7 +45,7 @@ class AgentSettings:
     )
     llm_analysis_model: str = field(
         default_factory=lambda: os.getenv(
-            "AGENT_LLM_MODEL", "claude-sonnet-4-20250514"
+            "AGENT_LLM_MODEL", "claude-sonnet-4-6"
         )
     )
 

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -17,7 +17,7 @@ from .config import agent_settings
 logger = logging.getLogger(__name__)
 
 # Analysis model - use Sonnet for cost efficiency
-DEFAULT_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 @dataclass
@@ -119,7 +119,7 @@ class LabelingAnalyzer:
 
         Args:
             api_key: Anthropic API key (default: from environment)
-            model: Model to use (default: claude-sonnet-4-20250514)
+            model: Model to use (default: claude-sonnet-4-6)
             max_retries: Maximum retry attempts for rate limits
             retry_delay: Initial delay between retries in seconds
         """

--- a/src/experiment_log/reflection.py
+++ b/src/experiment_log/reflection.py
@@ -16,7 +16,7 @@ from .models import ExperimentEntry, ExperimentReflection
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_MODEL = "claude-sonnet-4-6"
 
 REFLECTION_SYSTEM_PROMPT = """You are an ML experiment analyst reviewing a completed model training experiment.
 

--- a/src/labeling/config.py
+++ b/src/labeling/config.py
@@ -95,7 +95,7 @@ class LabelingSettings(BaseModel):
 
     # Model settings
     labeling_model: str = Field(
-        default_factory=lambda: os.getenv("LABELING_MODEL", "claude-sonnet-4-20250514")
+        default_factory=lambda: os.getenv("LABELING_MODEL", "claude-sonnet-4-6")
     )
 
     # Prompt version (None = use production version from registry)

--- a/src/migration_eval/__init__.py
+++ b/src/migration_eval/__init__.py
@@ -1,0 +1,42 @@
+"""Retrospective model-migration evaluation.
+
+Compares a candidate model's labeling decisions against the labels already
+stored in the database (produced by the outgoing model) to catch significant
+regressions before promoting the candidate to production.
+
+The comparison logic in :mod:`src.migration_eval.compare` is pure and
+DB/API-free so it can be unit-tested. The orchestration (DB sampling, API
+calls, reporting) lives in ``scripts/eval_model_migration.py``.
+"""
+
+from src.migration_eval.compare import (
+    build_verdict,
+    compare_article,
+    decisions_from_response,
+    effective_decision_from_analysis,
+    outcome_from_decisions,
+)
+from src.migration_eval.models import (
+    CATEGORIES,
+    ArticleComparison,
+    BrandComparison,
+    BrandDecision,
+    CategoryDiff,
+    MigrationVerdict,
+    Thresholds,
+)
+
+__all__ = [
+    "CATEGORIES",
+    "ArticleComparison",
+    "BrandComparison",
+    "BrandDecision",
+    "CategoryDiff",
+    "MigrationVerdict",
+    "Thresholds",
+    "build_verdict",
+    "compare_article",
+    "decisions_from_response",
+    "effective_decision_from_analysis",
+    "outcome_from_decisions",
+]

--- a/src/migration_eval/compare.py
+++ b/src/migration_eval/compare.py
@@ -1,0 +1,258 @@
+"""Pure comparison logic for model-migration evaluation.
+
+No DB or API access here — everything operates on plain data structures so it
+can be unit-tested without a database or live model. The orchestration script
+builds the baseline decisions from stored ``brand_labels`` and the candidate
+decisions from a fresh labeling run, then calls into these functions.
+
+The functions are deliberately generic ("baseline" vs "candidate" label sets)
+rather than hardcoding "DB vs live 4.6", so the same logic can back the general
+prompt/model contrastive harness (issue #4, #39).
+"""
+
+from __future__ import annotations
+
+from src.labeling.models import BrandAnalysis, LabelingResponse
+from src.migration_eval.models import (
+    CATEGORIES,
+    ArticleComparison,
+    BrandComparison,
+    BrandDecision,
+    CategoryDiff,
+    MigrationVerdict,
+    Thresholds,
+)
+
+
+def effective_decision_from_analysis(analysis: BrandAnalysis) -> BrandDecision | None:
+    """Derive the *persisted* decision for a brand, mirroring save_brand_labels.
+
+    Returns None when the brand would NOT be saved as a ``brand_labels`` row:
+    a non-sportswear brand (false positive), a brand with no category data, or a
+    sportswear brand where no ESG category applies. This makes the candidate
+    output apples-to-apples with the stored baseline, which only contains
+    sportswear brands with at least one applicable category.
+    """
+    if not analysis.is_sportswear_brand:
+        return None
+    if not analysis.categories:
+        return None
+    applies = {c: bool(analysis.categories.get(c) and analysis.categories[c].applies) for c in CATEGORIES}
+    if not any(applies.values()):
+        return None
+    sentiment = {
+        c: (analysis.categories[c].sentiment if c in analysis.categories else None)
+        for c in CATEGORIES
+    }
+    return BrandDecision(
+        brand=analysis.brand,
+        applies=applies,
+        sentiment=sentiment,
+        confidence=analysis.confidence,
+        reasoning=analysis.reasoning,
+    )
+
+
+def decisions_from_response(response: LabelingResponse) -> dict[str, BrandDecision]:
+    """Build {brand_lower: BrandDecision} for brands that would be persisted."""
+    decisions: dict[str, BrandDecision] = {}
+    for analysis in response.brand_analyses:
+        decision = effective_decision_from_analysis(analysis)
+        if decision is not None:
+            decisions[decision.brand.lower()] = decision
+    return decisions
+
+
+def outcome_from_decisions(decisions: dict[str, BrandDecision]) -> str:
+    """Article-level outcome implied by a set of effective decisions."""
+    return "labeled" if decisions else "false_positive"
+
+
+def compare_article(
+    article_id: str,
+    title: str,
+    baseline: dict[str, BrandDecision],
+    candidate: dict[str, BrandDecision],
+    *,
+    baseline_reasoning: str = "",
+    candidate_reasoning: str = "",
+    is_human_anchor: bool = False,
+    parse_ok: bool = True,
+    error: str | None = None,
+) -> ArticleComparison:
+    """Compare baseline vs candidate effective decisions for one article.
+
+    Brand keys are lowercased brand names. The brand universe is the union of
+    both sides, so brands dropped or newly added by the candidate are captured
+    as disagreements (and contribute to the category confusion counts).
+    """
+    brand_keys = sorted(set(baseline) | set(candidate))
+    brand_comparisons: list[BrandComparison] = []
+    for key in brand_keys:
+        b = baseline.get(key)
+        c = candidate.get(key)
+        diffs = [
+            CategoryDiff(
+                category=cat,
+                baseline_applies=bool(b and b.applies.get(cat)),
+                candidate_applies=bool(c and c.applies.get(cat)),
+                baseline_sentiment=(b.sentiment.get(cat) if b else None),
+                candidate_sentiment=(c.sentiment.get(cat) if c else None),
+            )
+            for cat in CATEGORIES
+        ]
+        brand_comparisons.append(
+            BrandComparison(
+                brand=(b.brand if b else c.brand),
+                in_baseline=b is not None,
+                in_candidate=c is not None,
+                category_diffs=diffs,
+            )
+        )
+
+    return ArticleComparison(
+        article_id=article_id,
+        title=title,
+        baseline_outcome=outcome_from_decisions(baseline),
+        candidate_outcome=outcome_from_decisions(candidate),
+        brand_comparisons=brand_comparisons,
+        baseline_reasoning=baseline_reasoning,
+        candidate_reasoning=candidate_reasoning,
+        is_human_anchor=is_human_anchor,
+        parse_ok=parse_ok,
+        error=error,
+    )
+
+
+def _f1(precision: float, recall: float) -> float:
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def build_verdict(
+    comparisons: list[ArticleComparison],
+    thresholds: Thresholds | None = None,
+    *,
+    total_input_tokens: int = 0,
+    total_output_tokens: int = 0,
+    estimated_cost_usd: float = 0.0,
+    mean_latency_s: float = 0.0,
+) -> MigrationVerdict:
+    """Aggregate comparisons into metrics + an advisory verdict.
+
+    Only articles that parsed successfully count toward the agreement metrics;
+    parse failures are tracked separately (and trigger a hard fail).
+    """
+    thresholds = thresholds or Thresholds()
+
+    n_parse_failures = sum(1 for c in comparisons if not c.parse_ok)
+    scored = [c for c in comparisons if c.parse_ok]
+    n = len(scored)
+
+    # Article-outcome confusion: first letter = baseline, second = candidate.
+    # l = labeled, f = false_positive.
+    confusion = {"ll": 0, "lf": 0, "fl": 0, "ff": 0}
+    for c in scored:
+        b = "l" if c.baseline_outcome == "labeled" else "f"
+        cand = "l" if c.candidate_outcome == "labeled" else "f"
+        confusion[b + cand] += 1
+
+    disagreements = confusion["lf"] + confusion["fl"]
+    outcome_disagreement_rate = disagreements / n if n else 0.0
+    baseline_fp = confusion["fl"] + confusion["ff"]
+    baseline_labeled = confusion["ll"] + confusion["lf"]
+    newly_labeled_rate = confusion["fl"] / baseline_fp if baseline_fp else 0.0
+    dropped_label_rate = confusion["lf"] / baseline_labeled if baseline_labeled else 0.0
+
+    # Per-category boolean confusion (baseline True = positive class).
+    cat_metrics: dict[str, dict[str, float]] = {}
+    f1s: list[float] = []
+    for cat in CATEGORIES:
+        tp = fp = fn = 0
+        for c in scored:
+            for bc in c.brand_comparisons:
+                d = next((x for x in bc.category_diffs if x.category == cat), None)
+                if d is None:
+                    continue
+                if d.baseline_applies and d.candidate_applies:
+                    tp += 1
+                elif not d.baseline_applies and d.candidate_applies:
+                    fp += 1
+                elif d.baseline_applies and not d.candidate_applies:
+                    fn += 1
+        precision = tp / (tp + fp) if (tp + fp) else 1.0
+        recall = tp / (tp + fn) if (tp + fn) else 1.0
+        f1 = _f1(precision, recall)
+        cat_metrics[cat] = {"precision": precision, "recall": recall, "f1": f1, "tp": tp, "fp": fp, "fn": fn}
+        f1s.append(f1)
+    category_f1_macro = sum(f1s) / len(f1s) if f1s else 0.0
+
+    # Sentiment agreement where both mark the category applicable.
+    sent_total = sent_exact = sent_within1 = 0
+    for c in scored:
+        for bc in c.brand_comparisons:
+            for d in bc.category_diffs:
+                if d.baseline_applies and d.candidate_applies:
+                    sent_total += 1
+                    if d.baseline_sentiment == d.candidate_sentiment:
+                        sent_exact += 1
+                    if (
+                        d.baseline_sentiment is not None
+                        and d.candidate_sentiment is not None
+                        and abs(d.baseline_sentiment - d.candidate_sentiment) <= 1
+                    ):
+                        sent_within1 += 1
+    sentiment_exact_rate = sent_exact / sent_total if sent_total else 1.0
+    sentiment_within1_rate = sent_within1 / sent_total if sent_total else 1.0
+
+    human_anchors = [c for c in scored if c.is_human_anchor]
+    n_human_anchor_disagreements = sum(1 for c in human_anchors if c.has_disagreement)
+
+    # Advisory flags (noise-screen; human triage is the real gate).
+    flags: list[str] = []
+    if n_parse_failures > thresholds.max_parse_failures:
+        flags.append(
+            f"HARD_FAIL: {n_parse_failures} parse/integration failure(s) "
+            f"(threshold {thresholds.max_parse_failures})"
+        )
+    if outcome_disagreement_rate > thresholds.max_outcome_disagreement:
+        flags.append(
+            f"INVESTIGATE: outcome disagreement {outcome_disagreement_rate:.1%} "
+            f"> {thresholds.max_outcome_disagreement:.0%}"
+        )
+    if newly_labeled_rate > thresholds.max_newly_labeled_rate:
+        flags.append(
+            f"INVESTIGATE: candidate newly labels {newly_labeled_rate:.1%} of baseline "
+            f"false-positives (scorecard-inflation risk) > {thresholds.max_newly_labeled_rate:.0%}"
+        )
+    if category_f1_macro < thresholds.min_category_f1:
+        flags.append(
+            f"INVESTIGATE: macro category F1 {category_f1_macro:.3f} "
+            f"< {thresholds.min_category_f1}"
+        )
+    if sentiment_exact_rate < thresholds.min_sentiment_exact:
+        flags.append(
+            f"INVESTIGATE: sentiment exact-match {sentiment_exact_rate:.1%} "
+            f"< {thresholds.min_sentiment_exact:.0%}"
+        )
+
+    return MigrationVerdict(
+        n_compared=n,
+        n_parse_failures=n_parse_failures,
+        outcome_confusion=confusion,
+        outcome_disagreement_rate=outcome_disagreement_rate,
+        newly_labeled_rate=newly_labeled_rate,
+        dropped_label_rate=dropped_label_rate,
+        category_metrics=cat_metrics,
+        category_f1_macro=category_f1_macro,
+        sentiment_exact_rate=sentiment_exact_rate,
+        sentiment_within1_rate=sentiment_within1_rate,
+        n_human_anchors=len(human_anchors),
+        n_human_anchor_disagreements=n_human_anchor_disagreements,
+        total_input_tokens=total_input_tokens,
+        total_output_tokens=total_output_tokens,
+        estimated_cost_usd=estimated_cost_usd,
+        mean_latency_s=mean_latency_s,
+        flags=flags,
+    )

--- a/src/migration_eval/models.py
+++ b/src/migration_eval/models.py
@@ -1,0 +1,171 @@
+"""Dataclasses for model-migration evaluation.
+
+These are pure data containers with no DB or API dependencies so the
+comparison logic in :mod:`src.migration_eval.compare` stays unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# ESG category keys, matching BrandAnalysis.categories / BrandLabel columns.
+# Note the column/key asymmetry for the digital category: the response model
+# and BrandLabel boolean use "digital_transformation", but the BrandLabel
+# sentiment column is "digital_sentiment".
+CATEGORIES: tuple[str, ...] = (
+    "environmental",
+    "social",
+    "governance",
+    "digital_transformation",
+)
+
+
+@dataclass(frozen=True)
+class BrandDecision:
+    """A single brand's effective ESG label for one article.
+
+    This is the apples-to-apples unit of comparison: it represents a brand
+    that *would be persisted* as a ``brand_labels`` row (sportswear brand with
+    at least one applicable category). Brands judged false-positive or with no
+    applicable category are represented by the *absence* of a BrandDecision.
+    """
+
+    brand: str
+    # Per-category applies flags, keyed by CATEGORIES.
+    applies: dict[str, bool]
+    # Per-category sentiment (-1/0/1 or None), keyed by CATEGORIES.
+    sentiment: dict[str, int | None]
+    confidence: float = 0.0
+    reasoning: str = ""
+
+    @property
+    def applicable_categories(self) -> list[str]:
+        return [c for c in CATEGORIES if self.applies.get(c)]
+
+
+@dataclass
+class CategoryDiff:
+    """Per-category disagreement detail for one (article, brand)."""
+
+    category: str
+    baseline_applies: bool
+    candidate_applies: bool
+    baseline_sentiment: int | None
+    candidate_sentiment: int | None
+
+    @property
+    def applies_match(self) -> bool:
+        return self.baseline_applies == self.candidate_applies
+
+    @property
+    def sentiment_match(self) -> bool:
+        # Only meaningful when both mark the category as applicable.
+        return self.baseline_sentiment == self.candidate_sentiment
+
+
+@dataclass
+class BrandComparison:
+    """Comparison of one brand across baseline and candidate for one article."""
+
+    brand: str
+    in_baseline: bool
+    in_candidate: bool
+    category_diffs: list[CategoryDiff] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        if self.in_baseline and self.in_candidate:
+            return "shared"
+        if self.in_baseline:
+            return "dropped"  # candidate no longer labels this brand
+        return "added"  # candidate newly labels this brand
+
+
+@dataclass
+class ArticleComparison:
+    """Full comparison for a single article."""
+
+    article_id: str
+    title: str
+    baseline_outcome: str  # "labeled" | "false_positive"
+    candidate_outcome: str  # "labeled" | "false_positive"
+    brand_comparisons: list[BrandComparison] = field(default_factory=list)
+    # Provenance / triage aids.
+    baseline_reasoning: str = ""
+    candidate_reasoning: str = ""
+    is_human_anchor: bool = False  # baseline includes a human_reviewed label
+    parse_ok: bool = True  # candidate response parsed successfully
+    error: str | None = None
+
+    @property
+    def outcome_match(self) -> bool:
+        return self.baseline_outcome == self.candidate_outcome
+
+    @property
+    def has_disagreement(self) -> bool:
+        if not self.parse_ok:
+            return True
+        if not self.outcome_match:
+            return True
+        for bc in self.brand_comparisons:
+            if bc.status != "shared":
+                return True
+            if any(
+                not d.applies_match or not d.sentiment_match for d in bc.category_diffs
+            ):
+                return True
+        return False
+
+
+@dataclass
+class Thresholds:
+    """Advisory pass/fail thresholds (a noise-screen, not the real gate).
+
+    The real gate is human adjudication of the disagreement table. These only
+    flag results worth a closer look.
+    """
+
+    # Any parse failure means the integration broke -> hard fail.
+    max_parse_failures: int = 0
+    # Fraction of compared articles whose labeled/false_positive outcome flips.
+    max_outcome_disagreement: float = 0.10
+    # Per-category boolean agreement F1 (candidate vs baseline as reference).
+    min_category_f1: float = 0.85
+    # Exact-match rate of sentiment where both mark a category applicable.
+    min_sentiment_exact: float = 0.80
+    # Fraction of baseline false-positive articles the candidate newly labels
+    # (scorecard-inflation risk).
+    max_newly_labeled_rate: float = 0.10
+
+
+@dataclass
+class MigrationVerdict:
+    """Aggregate metrics + advisory verdict over a set of comparisons."""
+
+    n_compared: int
+    n_parse_failures: int
+    outcome_confusion: dict[str, int]  # keys: ll, lf, fl, ff
+    outcome_disagreement_rate: float
+    newly_labeled_rate: float
+    dropped_label_rate: float
+    category_metrics: dict[str, dict[str, float]]  # category -> {precision,recall,f1}
+    category_f1_macro: float
+    sentiment_exact_rate: float
+    sentiment_within1_rate: float
+    n_human_anchors: int
+    n_human_anchor_disagreements: int
+    # Cost / performance.
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    estimated_cost_usd: float = 0.0
+    mean_latency_s: float = 0.0
+    # Advisory verdict.
+    flags: list[str] = field(default_factory=list)
+
+    @property
+    def hard_fail(self) -> bool:
+        return any(f.startswith("HARD_FAIL") for f in self.flags)
+
+    @property
+    def passed_advisory(self) -> bool:
+        return len(self.flags) == 0

--- a/src/workflow_learning/config.py
+++ b/src/workflow_learning/config.py
@@ -43,7 +43,7 @@ class WorkflowLearningSettings:
     # Analysis settings
     analysis_model: str = field(
         default_factory=lambda: os.getenv(
-            "WORKFLOW_ANALYSIS_MODEL", "claude-sonnet-4-20250514"
+            "WORKFLOW_ANALYSIS_MODEL", "claude-sonnet-4-6"
         )
     )
     anthropic_api_key: str | None = field(

--- a/tests/test_agent_llm.py
+++ b/tests/test_agent_llm.py
@@ -23,7 +23,7 @@ class TestAnalysisResult:
             analysis={"summary": "Good quality labeling"},
             input_tokens=100,
             output_tokens=50,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-6",
         )
 
         assert result.success is True
@@ -37,7 +37,7 @@ class TestAnalysisResult:
         result = AnalysisResult(
             success=False,
             error="API error occurred",
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-6",
         )
 
         assert result.success is False

--- a/tests/test_experiment_log/test_workflow_integration.py
+++ b/tests/test_experiment_log/test_workflow_integration.py
@@ -171,7 +171,7 @@ class TestFinalizeExperiments:
 
         mock_settings.llm_analysis_enabled = True
         mock_settings.anthropic_api_key = "test-key"
-        mock_settings.llm_analysis_model = "claude-sonnet-4-20250514"
+        mock_settings.llm_analysis_model = "claude-sonnet-4-6"
 
         context = {
             "experiment_ids": {"fp": "fp_20260226_143000"},

--- a/tests/test_migration_eval.py
+++ b/tests/test_migration_eval.py
@@ -1,0 +1,209 @@
+"""Unit tests for the pure model-migration comparison logic."""
+
+from src.labeling.models import BrandAnalysis, CategoryLabel, LabelingResponse
+from src.migration_eval.compare import (
+    build_verdict,
+    compare_article,
+    decisions_from_response,
+    effective_decision_from_analysis,
+    outcome_from_decisions,
+)
+from src.migration_eval.models import CATEGORIES, BrandDecision, Thresholds
+
+
+def _cat(applies: bool, sentiment: int | None = None) -> CategoryLabel:
+    return CategoryLabel(applies=applies, sentiment=sentiment, evidence=[])
+
+
+def _analysis(
+    brand: str,
+    *,
+    is_sportswear: bool = True,
+    env: tuple[bool, int | None] = (False, None),
+    soc: tuple[bool, int | None] = (False, None),
+    gov: tuple[bool, int | None] = (False, None),
+    dig: tuple[bool, int | None] = (False, None),
+    confidence: float = 0.9,
+    reasoning: str = "",
+) -> BrandAnalysis:
+    return BrandAnalysis(
+        brand=brand,
+        is_sportswear_brand=is_sportswear,
+        categories={
+            "environmental": _cat(*env),
+            "social": _cat(*soc),
+            "governance": _cat(*gov),
+            "digital_transformation": _cat(*dig),
+        },
+        confidence=confidence,
+        reasoning=reasoning,
+    )
+
+
+def _decision(
+    brand: str,
+    *,
+    env: tuple[bool, int | None] = (False, None),
+    soc: tuple[bool, int | None] = (False, None),
+    gov: tuple[bool, int | None] = (False, None),
+    dig: tuple[bool, int | None] = (False, None),
+) -> BrandDecision:
+    pairs = {"environmental": env, "social": soc, "governance": gov, "digital_transformation": dig}
+    return BrandDecision(
+        brand=brand,
+        applies={c: pairs[c][0] for c in CATEGORIES},
+        sentiment={c: pairs[c][1] for c in CATEGORIES},
+    )
+
+
+# --- effective_decision_from_analysis (mirrors save_brand_labels filter) ---
+
+
+def test_non_sportswear_brand_is_filtered_out():
+    a = _analysis("Puma", is_sportswear=False, env=(True, 1))
+    assert effective_decision_from_analysis(a) is None
+
+
+def test_brand_with_no_applicable_category_is_filtered_out():
+    a = _analysis("Nike")  # all categories False
+    assert effective_decision_from_analysis(a) is None
+
+
+def test_brand_with_empty_categories_is_filtered_out():
+    a = BrandAnalysis(brand="Nike", is_sportswear_brand=True, categories={})
+    assert effective_decision_from_analysis(a) is None
+
+
+def test_valid_sportswear_brand_yields_decision():
+    a = _analysis("Nike", env=(True, -1), gov=(True, 1))
+    d = effective_decision_from_analysis(a)
+    assert d is not None
+    assert d.applies["environmental"] is True
+    assert d.applies["governance"] is True
+    assert d.applies["social"] is False
+    assert d.sentiment["environmental"] == -1
+    assert d.sentiment["governance"] == 1
+    assert d.applicable_categories == ["environmental", "governance"]
+
+
+def test_decisions_from_response_keys_lowercased_and_filtered():
+    resp = LabelingResponse(
+        brand_analyses=[
+            _analysis("Nike", env=(True, 1)),
+            _analysis("Adidas", is_sportswear=False, env=(True, 1)),  # FP, dropped
+            _analysis("Puma"),  # no categories apply, dropped
+        ],
+        article_summary="x",
+    )
+    decisions = decisions_from_response(resp)
+    assert set(decisions) == {"nike"}
+
+
+def test_outcome_from_decisions():
+    assert outcome_from_decisions({}) == "false_positive"
+    assert outcome_from_decisions({"nike": _decision("Nike", env=(True, 1))}) == "labeled"
+
+
+# --- compare_article ---
+
+
+def test_compare_shared_brand_full_agreement_has_no_disagreement():
+    base = {"nike": _decision("Nike", env=(True, 1))}
+    cand = {"nike": _decision("Nike", env=(True, 1))}
+    comp = compare_article("a1", "t", base, cand)
+    assert comp.outcome_match
+    assert not comp.has_disagreement
+    assert comp.brand_comparisons[0].status == "shared"
+
+
+def test_compare_detects_dropped_and_added_brands():
+    base = {"nike": _decision("Nike", env=(True, 1))}
+    cand = {"adidas": _decision("Adidas", soc=(True, 0))}
+    comp = compare_article("a1", "t", base, cand)
+    statuses = {bc.brand: bc.status for bc in comp.brand_comparisons}
+    assert statuses == {"Nike": "dropped", "Adidas": "added"}
+    assert comp.has_disagreement
+
+
+def test_compare_detects_outcome_flip():
+    base: dict[str, BrandDecision] = {}  # baseline false_positive
+    cand = {"nike": _decision("Nike", env=(True, 1))}  # candidate labeled
+    comp = compare_article("a1", "t", base, cand)
+    assert comp.baseline_outcome == "false_positive"
+    assert comp.candidate_outcome == "labeled"
+    assert not comp.outcome_match
+
+
+def test_compare_detects_sentiment_disagreement():
+    base = {"nike": _decision("Nike", env=(True, 1))}
+    cand = {"nike": _decision("Nike", env=(True, -1))}
+    comp = compare_article("a1", "t", base, cand)
+    assert comp.outcome_match  # both labeled
+    assert comp.has_disagreement  # sentiment differs
+    env_diff = next(
+        d for d in comp.brand_comparisons[0].category_diffs if d.category == "environmental"
+    )
+    assert env_diff.applies_match
+    assert not env_diff.sentiment_match
+
+
+# --- build_verdict ---
+
+
+def test_verdict_hard_fails_on_parse_failure():
+    comps = [
+        compare_article("a1", "t", {}, {}, parse_ok=False, error="bad json"),
+        compare_article("a2", "t", {"nike": _decision("Nike", env=(True, 1))}, {"nike": _decision("Nike", env=(True, 1))}),
+    ]
+    v = build_verdict(comps)
+    assert v.n_parse_failures == 1
+    assert v.n_compared == 1  # parse failures excluded from scored set
+    assert v.hard_fail
+
+
+def test_verdict_clean_run_passes_advisory():
+    comps = [
+        compare_article(f"a{i}", "t", {"nike": _decision("Nike", env=(True, 1))}, {"nike": _decision("Nike", env=(True, 1))})
+        for i in range(10)
+    ]
+    v = build_verdict(comps)
+    assert v.passed_advisory
+    assert v.outcome_disagreement_rate == 0.0
+    assert v.category_f1_macro == 1.0
+    assert v.sentiment_exact_rate == 1.0
+
+
+def test_verdict_flags_outcome_disagreement_and_inflation():
+    # 8 agree (false_positive), 2 flip fp->labeled (newly labeled).
+    comps = [compare_article(f"f{i}", "t", {}, {}) for i in range(8)]
+    comps += [
+        compare_article(f"x{i}", "t", {}, {"nike": _decision("Nike", env=(True, 1))})
+        for i in range(2)
+    ]
+    v = build_verdict(comps, Thresholds(max_outcome_disagreement=0.10, max_newly_labeled_rate=0.10))
+    assert v.outcome_confusion["fl"] == 2
+    assert v.outcome_confusion["ff"] == 8
+    assert v.outcome_disagreement_rate == 0.2
+    assert v.newly_labeled_rate == 0.2
+    assert any("outcome disagreement" in f for f in v.flags)
+    assert any("scorecard-inflation" in f for f in v.flags)
+    assert not v.hard_fail
+
+
+def test_verdict_category_confusion_counts():
+    # baseline labels env, candidate labels social -> 1 FN env, 1 FP social.
+    base = {"nike": _decision("Nike", env=(True, 1))}
+    cand = {"nike": _decision("Nike", soc=(True, 1))}
+    v = build_verdict([compare_article("a1", "t", base, cand)])
+    assert v.category_metrics["environmental"]["fn"] == 1
+    assert v.category_metrics["social"]["fp"] == 1
+
+
+def test_verdict_tracks_human_anchor_disagreements():
+    comps = [
+        compare_article("a1", "t", {"nike": _decision("Nike", env=(True, 1))}, {"nike": _decision("Nike", env=(True, -1))}, is_human_anchor=True),
+        compare_article("a2", "t", {"nike": _decision("Nike", env=(True, 1))}, {"nike": _decision("Nike", env=(True, 1))}, is_human_anchor=True),
+    ]
+    v = build_verdict(comps)
+    assert v.n_human_anchors == 2
+    assert v.n_human_anchor_disagreements == 1

--- a/tests/test_workflow_learning/test_config.py
+++ b/tests/test_workflow_learning/test_config.py
@@ -33,7 +33,7 @@ class TestWorkflowLearningSettings:
             from src.workflow_learning.config import WorkflowLearningSettings
 
             settings = WorkflowLearningSettings()
-            assert settings.analysis_model == "claude-sonnet-4-20250514"
+            assert settings.analysis_model == "claude-sonnet-4-6"
 
     def test_sessions_dir_property(self, tmp_path):
         """Test sessions_dir property."""

--- a/tests/test_workflow_learning/test_models.py
+++ b/tests/test_workflow_learning/test_models.py
@@ -332,7 +332,7 @@ class TestAnalysisResult:
             skill_description="A test workflow",
             input_tokens=1000,
             output_tokens=500,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-6",
         )
 
         assert result.success is True
@@ -346,7 +346,7 @@ class TestAnalysisResult:
         result = AnalysisResult(
             success=False,
             error="API rate limited",
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-6",
         )
 
         assert result.success is False

--- a/tests/test_workflow_learning/test_skill_generator.py
+++ b/tests/test_workflow_learning/test_skill_generator.py
@@ -71,7 +71,7 @@ def sample_analysis():
         skill_description="Train the false positive classifier model",
         input_tokens=2000,
         output_tokens=800,
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
     )
 
 


### PR DESCRIPTION
## Why

`claude-sonnet-4-20250514` was **retired**, which broke the daily labeling job (no labels produced for ~2 days). This migrates every Sonnet call site to `claude-sonnet-4-6` and restores the job — but gated behind a retrospective evaluation rather than a blind swap.

Closes #38.

## What's in here

**1. Retrospective model-migration eval harness** (`src/migration_eval/`, `scripts/eval_model_migration.py`)
Since Sonnet 4 is gone, a live A/B is impossible. Instead the harness re-labels a stratified sample of already-labeled articles with the candidate model and diffs against the stored Sonnet-4 labels.
- Pure, unit-tested comparison logic (15 tests); thin DB/API orchestration with a dry-run mode.
- Methodology guards: scope to one production regime (Sonnet 4 under prompt v1.8.0, re-label with v1.8.0 → isolates the *model* change); exclude FP-classifier pre-filter skips and dedup from the baseline; separate human-reviewed anchor stratum; a pending/never-labeled stratum for human-only adjudication.
- Numeric verdict is an advisory noise-screen; human review of disagreements is the gate.

**2. The model flip**
- Prompt **v1.9.0** (byte-identical text to v1.8.0, model `claude-sonnet-4-6`), promoted to production → clean before/after split in `brand_labels.prompt_version`/`model_version`. Historical v1.0.0–v1.8.0 entries keep their original model string.
- All four runtime defaults → `claude-sonnet-4-6`: labeling (`LABELING_MODEL`), agent analysis (`AGENT_LLM_MODEL` + `agent/llm.py`), workflow-learning (`WORKFLOW_ANALYSIS_MODEL`), experiment reflection.
- Test assertions + docs updated.

## Eval results (299 articles, prompt v1.8.0, Sonnet 4 vs 4.6)

| Signal | Result |
|---|---|
| Newly-labeled rate (baseline FP → 4.6 labeled) | **0.0%** — no scorecard-inflation risk |
| Parse/integration failures | **0/299** |
| Sentiment agreement | **92.4% exact / 100% within ±1** |
| Outcome disagreement | 11.7% — **all** labeled→FP, dominated by 4.6 fixing brand-name false positives Sonnet 4 mislabeled (e.g. "forensic vans", "pumas in Patagonia", "Skechers ex-director") |

4.6 is more conservative/precise and arguably more accurate than the retired model. One observation filed as a follow-up: a handful of layoffs/closures articles where 4.6 drops the `social` category (prompt-policy question, not a model defect).

## Test plan

- [x] Full pytest suite: **1264 passed, 24 skipped** (DB tests)
- [x] 15 new unit tests for comparison logic
- [x] End-to-end live run against `claude-sonnet-4-6` (300+ articles, HTTP 200, reports generated)
- [x] Verified all defaults + production prompt resolve to 4.6 / v1.9.0
- [x] CI green

## Remaining manual items

- The env template is hook-protected (couldn't edit): if it pins the labeling/agent/workflow model vars to the old string, update them to `claude-sonnet-4-6`. (Live config already updated by the maintainer.)
- After merge: run `daily_labeling` once under supervision to clear the backlog, then watch the first 4.6 batch's label distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
