### PR TITLE
Fix agent analysis JSON truncation under Sonnet 4.6 (#42)

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 # Analysis model - use Sonnet for cost efficiency
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
+# Max output tokens for the analysis call. Sonnet 4.6 produces a richer analysis
+# than the retired Sonnet 4, so the old 2000 cap truncated the JSON mid-structure
+# (see issue #42). Give generous headroom; the prompt also bounds list lengths so
+# responses stay well under this in practice. Non-streaming, so kept under the
+# ~16K SDK HTTP-timeout guideline.
+ANALYSIS_MAX_TOKENS = 8000
+
 
 @dataclass
 class AnalysisResult:
@@ -30,6 +37,7 @@ class AnalysisResult:
     input_tokens: int = 0
     output_tokens: int = 0
     model: str = ""
+    truncated: bool = False
 
 
 LABELING_ANALYSIS_SYSTEM_PROMPT = """You are an expert data quality analyst reviewing article labeling results for an ESG (Environmental, Social, Governance) news classification system focused on sportswear brands.
@@ -70,7 +78,10 @@ LABELING_ANALYSIS_USER_PROMPT = """Analyze the following labeling results from t
 ## Recent Skipped Articles (sample)
 {skipped_articles_sample}
 
-Please analyze these results and respond with a JSON object in this format:
+Please analyze these results and respond with a JSON object in this format.
+Limit `potential_errors`, `patterns_detected`, and `improvement_suggestions` to
+at most 5 items each, prioritizing the most significant findings. Keep each
+string field concise so the JSON response stays complete:
 {{
     "overall_assessment": "brief assessment of labeling quality",
     "potential_errors": [
@@ -212,11 +223,33 @@ class LabelingAnalyzer:
 
                 response = self.client.messages.create(
                     model=self.model,
-                    max_tokens=2000,
+                    max_tokens=ANALYSIS_MAX_TOKENS,
                     temperature=0.0,
                     system=LABELING_ANALYSIS_SYSTEM_PROMPT,
                     messages=[{"role": "user", "content": user_prompt}],
                 )
+
+                # A max_tokens stop means the JSON was cut off mid-structure and
+                # the structured fields would silently parse to empty. Surface it
+                # as a failure rather than letting it masquerade as a clean run.
+                if getattr(response, "stop_reason", None) == "max_tokens":
+                    logger.error(
+                        "LLM analysis truncated: hit max_tokens cap of "
+                        f"{ANALYSIS_MAX_TOKENS} ({response.usage.output_tokens} "
+                        "output tokens). JSON is incomplete; raise ANALYSIS_MAX_TOKENS "
+                        "or tighten the prompt."
+                    )
+                    return AnalysisResult(
+                        success=False,
+                        error=(
+                            "Analysis response truncated at max_tokens "
+                            f"({ANALYSIS_MAX_TOKENS}); JSON incomplete"
+                        ),
+                        input_tokens=response.usage.input_tokens,
+                        output_tokens=response.usage.output_tokens,
+                        model=self.model,
+                        truncated=True,
+                    )
 
                 # Extract response text
                 response_text = response.content[0].text

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -232,12 +232,16 @@ class LabelingAnalyzer:
                 # A max_tokens stop means the JSON was cut off mid-structure and
                 # the structured fields would silently parse to empty. Surface it
                 # as a failure rather than letting it masquerade as a clean run.
-                if getattr(response, "stop_reason", None) == "max_tokens":
+                if response.stop_reason == "max_tokens":
                     logger.error(
                         "LLM analysis truncated: hit max_tokens cap of "
                         f"{ANALYSIS_MAX_TOKENS} ({response.usage.output_tokens} "
                         "output tokens). JSON is incomplete; raise ANALYSIS_MAX_TOKENS "
                         "or tighten the prompt."
+                    )
+                    logger.debug(
+                        "Truncated analysis (first 500 chars): %s",
+                        response.content[0].text[:500],
                     )
                     return AnalysisResult(
                         success=False,

--- a/src/agent/workflows/daily_labeling.py
+++ b/src/agent/workflows/daily_labeling.py
@@ -327,6 +327,7 @@ def run_llm_analysis(workflow: Workflow, context: dict[str, Any]) -> dict[str, A
             return {
                 "llm_analysis_completed": False,
                 "llm_analysis_error": result.error,
+                "llm_analysis_truncated": result.truncated,
             }
 
     except Exception as e:
@@ -383,6 +384,12 @@ def generate_report(workflow: Workflow, context: dict[str, Any]) -> dict[str, An
         "completed": context.get("llm_analysis_completed", False),
         "skipped": context.get("llm_analysis_skipped", False),
     }
+
+    # Surface failure detail so a truncated/errored analysis is visible in the
+    # report rather than rendering identically to "not run" (see issue #42).
+    if not context.get("llm_analysis_completed") and context.get("llm_analysis_error"):
+        report["llm_analysis"]["error"] = context.get("llm_analysis_error")
+        report["llm_analysis"]["truncated"] = context.get("llm_analysis_truncated", False)
 
     # Include LLM analysis details if available
     if context.get("llm_analysis_completed"):

--- a/tests/test_agent_llm.py
+++ b/tests/test_agent_llm.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agent.llm import (
+    ANALYSIS_MAX_TOKENS,
     AnalysisResult,
     LABELING_ANALYSIS_SYSTEM_PROMPT,
     LABELING_ANALYSIS_USER_PROMPT,
@@ -53,6 +54,7 @@ class TestAnalysisResult:
         assert result.input_tokens == 0
         assert result.output_tokens == 0
         assert result.model == ""
+        assert result.truncated is False
 
 
 class TestLabelingAnalyzerInit:
@@ -357,6 +359,43 @@ class TestAnalyzeLabelingResults:
         assert result.analysis == {"summary": "Analysis complete", "score": 85}
         assert result.input_tokens == 1000
         assert result.output_tokens == 200
+        assert result.truncated is False
+
+    def test_uses_generous_max_tokens(self, analyzer):
+        """Should request enough output tokens to avoid truncation (issue #42)."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"summary": "OK"}')]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_response.stop_reason = "end_turn"
+        analyzer.client.messages.create.return_value = mock_response
+
+        analyzer.analyze_labeling_results(
+            stats={}, labeled_sample=[], fp_sample=[], skipped_sample=[]
+        )
+
+        _, kwargs = analyzer.client.messages.create.call_args
+        assert kwargs["max_tokens"] == ANALYSIS_MAX_TOKENS
+        assert ANALYSIS_MAX_TOKENS > 2000
+
+    def test_truncated_response_is_failure(self, analyzer):
+        """A max_tokens stop should surface as a failure, not a clean empty result."""
+        mock_response = MagicMock()
+        # Incomplete JSON, exactly as it arrives when cut off mid-structure.
+        mock_response.content = [MagicMock(text='{"overall_assessment": "good", "poten')]
+        mock_response.usage.input_tokens = 2309
+        mock_response.usage.output_tokens = ANALYSIS_MAX_TOKENS
+        mock_response.stop_reason = "max_tokens"
+        analyzer.client.messages.create.return_value = mock_response
+
+        result = analyzer.analyze_labeling_results(
+            stats={}, labeled_sample=[], fp_sample=[], skipped_sample=[]
+        )
+
+        assert result.success is False
+        assert result.truncated is True
+        assert "truncated" in result.error.lower()
+        assert result.output_tokens == ANALYSIS_MAX_TOKENS
 
     def test_handles_api_error(self, analyzer):
         """Should handle API errors gracefully."""

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -498,6 +498,39 @@ Errors (5):
         assert stats["error_types"]["connection"] == 3
         assert stats["error_types"]["timeout"] == 2
 
+    def test_report_surfaces_truncated_analysis(self):
+        """A truncated analysis should be visible in the report, not look like 'not run' (#42)."""
+        from src.agent.workflows.daily_labeling import generate_report
+
+        workflow = MagicMock()
+        workflow.name = "daily_labeling"
+        context = {
+            "llm_analysis_completed": False,
+            "llm_analysis_error": "Analysis response truncated at max_tokens (8000); JSON incomplete",
+            "llm_analysis_truncated": True,
+        }
+
+        result = generate_report(workflow, context)
+        llm = result["report"]["llm_analysis"]
+
+        assert llm["completed"] is False
+        assert llm["truncated"] is True
+        assert "truncated" in llm["error"].lower()
+
+    def test_report_omits_error_when_analysis_not_run(self):
+        """No error key when analysis was skipped rather than failed (#42)."""
+        from src.agent.workflows.daily_labeling import generate_report
+
+        workflow = MagicMock()
+        workflow.name = "daily_labeling"
+        context = {"llm_analysis_skipped": True}
+
+        result = generate_report(workflow, context)
+        llm = result["report"]["llm_analysis"]
+
+        assert llm["completed"] is False
+        assert "error" not in llm
+
 
 class TestWebsiteExportWorkflow:
     """Tests for WebsiteExportWorkflow."""


### PR DESCRIPTION
## Summary

Fixes #42. After the Sonnet 4 → 4.6 migration, the `daily_labeling` LLM-analysis step truncated its JSON response at the 2000-token `max_tokens` cap. The richer Sonnet 4.6 output overran the cap, the JSON was cut off mid-structure, and the structured fields (`potential_errors` / `patterns_detected` / `improvement_suggestions`) silently parsed to empty — making a failed analysis read as a clean run.

## Changes

- **Raise the cap.** `max_tokens` for the analysis call is now `ANALYSIS_MAX_TOKENS` (8000), a module constant with generous headroom over the observed ~2000-token overrun, kept under the non-streaming SDK HTTP-timeout guideline.
- **Bound the lists.** The user prompt now caps `potential_errors`, `patterns_detected`, and `improvement_suggestions` at 5 items each so responses stay complete.
- **Surface truncation.** A `max_tokens` stop reason is now logged explicitly and returned as `AnalysisResult(success=False, truncated=True, ...)` instead of degrading to empty counts. The daily report's existing `result.success` branch then reports it as a failure rather than a clean run.

## Test plan

- `uv run pytest tests/test_agent_llm.py` — 32 passed, including new cases:
  - `test_uses_generous_max_tokens` — asserts the call requests `ANALYSIS_MAX_TOKENS` (> 2000)
  - `test_truncated_response_is_failure` — a `max_tokens` stop yields `success=False`, `truncated=True`
  - `truncated` default assertions on `AnalysisResult`
- `uv run pytest tests/test_agent_workflows.py tests/test_agent_llm.py` — 80 passed (consumer workflow unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)