### PR TITLE
Use uv run --frozen for scheduled jobs to survive DNS flakiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,27 @@ uv run pytest -v
 RUN_DB_TESTS=1 uv run pytest tests/test_database.py
 ```
 
+## Dependencies & Scheduled Jobs
+
+Cron jobs (collection, scraping, agent workflows, drift monitoring) and the
+agent's in-process script calls run `uv run --frozen`. `--frozen` uses the
+already-provisioned virtual environment with **no network resolution**, so the
+early-morning cron window does not fail trying to re-fetch the direct-URL
+spaCy model dependency (`en-core-web-sm`) from GitHub when DNS is flaky
+(see issue #45). The trade-off: cron will **not** auto-resolve dependency
+changes — it fails loudly on a stale lockfile instead.
+
+**After changing dependencies** (editing `pyproject.toml`), reconcile the env
+manually so the next scheduled run picks up the change:
+
+```bash
+uv lock      # update uv.lock to match pyproject.toml
+uv sync      # install the resolved dependencies into .venv
+```
+
+If a scheduled job logs a `uv run --frozen` lockfile error, the venv is out of
+sync — run the two commands above.
+
 ## Quick Reference
 
 ```bash

--- a/scripts/cron_agent.sh
+++ b/scripts/cron_agent.sh
@@ -26,8 +26,12 @@ echo "========================================" >> "$LOG_FILE"
 
 cd "$PROJECT_DIR"
 
-# Run agent workflow
-~/.local/bin/uv run python -m src.agent run "$WORKFLOW" >> "$LOG_FILE" 2>&1
+# Run agent workflow.
+# --frozen: run from the provisioned venv with no network resolution. Cron
+# fires in an early-morning window where DNS is intermittently down; without
+# this, uv re-fetches the direct-URL spaCy model dep from GitHub and aborts
+# before any Python runs. Fails loudly if the lockfile is stale. See issue #45.
+~/.local/bin/uv run --frozen python -m src.agent run "$WORKFLOW" >> "$LOG_FILE" 2>&1
 EXIT_CODE=$?
 
 echo "" >> "$LOG_FILE"

--- a/scripts/cron_collect.sh
+++ b/scripts/cron_collect.sh
@@ -32,7 +32,9 @@ echo "========================================" >> "$LOG_FILE"
 # Use uv to run the script in the project's virtual environment
 # Default mode is brand-only queries (no keyword filtering)
 # Add --with-keywords to use the old brand + keyword combination queries
-~/.local/bin/uv run python scripts/collect_news.py \
+# --frozen: no network resolution at run time so the early-morning cron run
+# does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
+~/.local/bin/uv run --frozen python scripts/collect_news.py \
     --max-calls 50 \
     --scrape-limit 100 \
     >> "$LOG_FILE" 2>&1

--- a/scripts/cron_monitor.sh
+++ b/scripts/cron_monitor.sh
@@ -54,8 +54,10 @@ run_monitoring() {
         ARGS="$ARGS --alert"
     fi
 
-    # Run monitoring script
-    if uv run python scripts/monitor_drift.py $ARGS >> "$LOG_FILE" 2>&1; then
+    # Run monitoring script.
+    # --frozen: no network resolution at run time so the early-morning cron run
+    # does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
+    if uv run --frozen python scripts/monitor_drift.py $ARGS >> "$LOG_FILE" 2>&1; then
         log "Drift monitoring completed successfully for $classifier"
         return 0
     else

--- a/scripts/cron_scrape.sh
+++ b/scripts/cron_scrape.sh
@@ -26,7 +26,9 @@ echo "GDELT collection started: $(date)" >> "$LOG_FILE"
 echo "========================================" >> "$LOG_FILE"
 
 # Use uv to run GDELT collection with 6-hour timespan
-~/.local/bin/uv run python scripts/collect_news.py \
+# --frozen: no network resolution at run time so the early-morning cron run
+# does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
+~/.local/bin/uv run --frozen python scripts/collect_news.py \
     --source gdelt \
     --timespan 6h \
     --max-calls 50 \

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -255,7 +255,12 @@ def run_uv_script(
         ScriptResult with execution details
     """
     uv_path = _get_uv_path()
-    command = [uv_path, "run", "python", script_path]
+    # --frozen: run from the already-provisioned venv with zero network
+    # resolution, and fail loudly if the lockfile is stale. Cron runs in an
+    # early-morning window where DNS is intermittently unavailable; without
+    # this, uv tries to re-fetch the direct-URL spaCy model dep from GitHub
+    # and aborts before any Python runs. See issue #45.
+    command = [uv_path, "run", "--frozen", "python", script_path]
     if args:
         command.extend(args)
     return run_script(command, **kwargs)

--- a/src/agent/workflows/model_training.py
+++ b/src/agent/workflows/model_training.py
@@ -585,7 +585,8 @@ def promote_model(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]
         # The notebooks have already trained the model, we just need to register it
         result = run_script(
             [
-                "uv", "run", "python", "scripts/register_model.py",
+                # --frozen: no network resolution at run time (see issue #45)
+                "uv", "run", "--frozen", "python", "scripts/register_model.py",
                 "--classifier", classifier,
                 "--bump", "minor",  # Default to minor version bump
                 "--update-registry",

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -263,8 +263,11 @@ class TestRunUvScript:
             called_command = mock_run.call_args[0][0]
             # First element should be uv path (may be full path or just 'uv')
             assert called_command[0].endswith("uv")
+            # --frozen ensures cron runs use the provisioned venv with no
+            # network resolution (issue #45).
             assert called_command[1:] == [
                 "run",
+                "--frozen",
                 "python",
                 "scripts/test.py",
                 "--flag",


### PR DESCRIPTION
Closes #45

## Problem

All cron jobs that call `uv run` failed every morning since Jun 14 (no labeling report email, no drift report, no website export, missed 06:00 collection). `uv run` re-validates the lockfile on each invocation and contacts GitHub to fetch metadata for the `en-core-web-sm` spaCy model (a direct-URL dep in `pyproject.toml`). In the early-morning cron window DNS is intermittently unavailable, so uv aborts **before any Python runs** — even though the model is already installed locally.

See issue #45 for full detection trail and the architect review.

## Fix

Add `--frozen` to **every** `uv run` call site so scheduled runs use the already-provisioned venv with zero network resolution, and fail loudly on a stale lockfile rather than silently re-fetching:

- `src/agent/runner.py` — the child process spawned by every agent workflow (the architect flagged that a wrapper-only fix would silently regress, since workflows re-invoke `uv run` from Python)
- `src/agent/workflows/model_training.py` — `register_model` call
- All **four** cron wrappers: `cron_agent.sh`, `cron_collect.sh`, `cron_scrape.sh`, `cron_monitor.sh`

Documented the operational contract in `CONTRIBUTING.md`: run `uv lock && uv sync` after dependency changes, since cron no longer auto-resolves.

## Design notes

- Chose `--frozen` over `--no-sync` (per architect): `--frozen` does zero network resolution **and** fails loudly on a stale lockfile, instead of silently running a possibly-stale env.
- Dropped a proposed preflight self-heal helper — its recovery path runs `uv sync`, i.e. the exact network op failing in this bug.
- Vendoring the spaCy model (dropping the direct-URL dep) is deferred to a separate issue.

## Test plan

- [x] `uv run --frozen pytest tests/test_agent_runner.py tests/test_retrain.py` — 63 passed (updated the command-structure assertion).
- [x] `bash -n` syntax-checks all four wrappers.
- [x] **Offline end-to-end** under network isolation (`unshare -rn`): `uv run --frozen` imports the model and runs; plain `uv run` reproduces the exact production error (`dns error: Temporary failure in name resolution`). This both confirms the root cause and proves the fix.
- [ ] CI full suite.
- [ ] Post-merge: confirm next morning's 05:30–07:00 cron logs are full-size again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)