### PR TITLE
Fix flaky dedup tests by mocking HuggingFace model download (#47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,11 @@ CLASSIFIER_TYPE=fp uv run python scripts/predict.py            # Start FP API (p
 CLASSIFIER_TYPE=ep uv run python scripts/predict.py            # Start EP API (port 8000)
 
 # Testing
-uv run pytest                              # Run all tests (1186 tests)
+uv run pytest                              # Run all tests
 uv run pytest -v                           # Run with verbose output
 uv run pytest --cov=src                    # Run with coverage report
 RUN_DB_TESTS=1 uv run pytest tests/test_database.py  # Run database tests (requires PostgreSQL)
+RUN_MODEL_TESTS=1 uv run pytest tests/test_deduplication.py  # Run opt-in tests that download the real sentence-transformer model (network)
 
 # Scheduled Collection (cron)
 ./scripts/setup_cron.sh install            # Set up both cron jobs
@@ -287,7 +288,7 @@ Records user workflows via Screenpipe and generates replayable Agent Skills usin
 - `src/fp3_nb/` - Deployment: threshold_optimization, deployment
 - `src/ep1_nb/`, `src/ep2_nb/`, `src/ep3_nb/` - Same structure for EP classifier
 
-### Test Suite (`tests/`) - 1186 tests
+### Test Suite (`tests/`)
 Core tests: test_api_client, test_gdelt_client, test_scraper, test_collector, test_database, test_chunker, test_labeler, test_embedder, test_evidence_matcher, test_labeling_pipeline, test_deployment, test_explainability, test_mlops_*, test_retrain, test_agent_*, test_scorecard_database, test_experiment_log/*, test_workflow_learning/*, test_integration
 
 ### Database Schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,43 @@
 """Pytest fixtures for ESG News Classifier tests."""
 
+import hashlib
+
+import numpy as np
 import pytest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from src.data_collection.api_client import ArticleData
+
+
+@pytest.fixture
+def fake_embed_texts():
+    """Deterministic stand-in for sentence-transformer embedding.
+
+    Maps each unique text to a fixed pseudo-random unit vector, so identical
+    texts get cosine similarity 1.0 and distinct texts are near-orthogonal
+    (~0 in high dimensions). This lets tests exercise embedding-dependent logic
+    (e.g. deduplication clustering) without downloading the real
+    ``all-MiniLM-L6-v2`` model from HuggingFace Hub, which makes CI flaky when
+    the Hub rate-limits the runner (see issue #47).
+
+    Returns a callable ``embed(texts, dim=384) -> np.ndarray`` of shape
+    ``(len(texts), dim)`` suitable for feeding straight into
+    ``sklearn.metrics.pairwise.cosine_similarity``.
+    """
+
+    def _embed(texts: list[str], dim: int = 384) -> np.ndarray:
+        vectors = []
+        for text in texts:
+            # Stable, process-independent seed derived from the text itself.
+            seed = int.from_bytes(hashlib.sha256(text.encode("utf-8")).digest()[:8], "big")
+            rng = np.random.default_rng(seed)
+            vec = rng.standard_normal(dim)
+            norm = np.linalg.norm(vec)
+            vectors.append(vec / norm if norm else vec)
+        return np.array(vectors)
+
+    return _embed
 
 
 @pytest.fixture

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,6 +1,7 @@
 """Tests for article deduplication logic."""
 
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,37 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from export_website_feed import deduplicate_articles
+
+
+def _run_model_tests() -> bool:
+    """Whether to run tests that download the real sentence-transformer model."""
+    return os.environ.get("RUN_MODEL_TESTS") == "1"
+
+
+# Tests decorated with this download `all-MiniLM-L6-v2` from HuggingFace Hub at
+# runtime, which makes CI non-deterministic when the Hub rate-limits the runner
+# (issue #47). They are opt-in, mirroring the RUN_DB_TESTS gate for DB tests.
+requires_real_model = pytest.mark.skipif(
+    not _run_model_tests(),
+    reason="Loads the real sentence-transformer model. Set RUN_MODEL_TESTS=1 to run.",
+)
+
+
+@pytest.fixture
+def patch_novelty_embedder(fake_embed_texts):
+    """Patch NoveltyScorer.embed_texts with a deterministic offline stub.
+
+    deduplicate_articles() constructs a NoveltyScorer and calls embed_texts(),
+    which would otherwise download the real model. Patching the class attribute
+    works regardless of the function-local import in export_website_feed.
+    """
+    from src.deployment.novelty import NoveltyScorer
+
+    def _bound(self, texts, show_progress=False):
+        return fake_embed_texts(texts)
+
+    with patch.object(NoveltyScorer, "embed_texts", _bound):
+        yield
 
 
 class TestGreedyCosineClustering:
@@ -312,8 +344,9 @@ class TestLabeledPairEvaluation:
 class TestSentenceTransformerEmbedder:
     """Tests for the sentence transformer embedder."""
 
+    @requires_real_model
     def test_embedding_dimension(self):
-        """Should produce correct embedding dimension."""
+        """Should produce correct embedding dimension (real model)."""
         from src.dedup1_nb.embedders import SentenceTransformerEmbedder
 
         embedder = SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2")
@@ -324,8 +357,9 @@ class TestSentenceTransformerEmbedder:
         assert embeddings.shape == (2, 384)
         assert embedder.embedding_dim == 384
 
+    @requires_real_model
     def test_normalized_embeddings(self):
-        """Normalized embeddings should have unit norm."""
+        """Normalized embeddings should have unit norm (real model)."""
         from src.dedup1_nb.embedders import SentenceTransformerEmbedder
 
         embedder = SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2", normalize=True)
@@ -335,6 +369,29 @@ class TestSentenceTransformerEmbedder:
 
         norms = np.linalg.norm(embeddings, axis=1)
         np.testing.assert_array_almost_equal(norms, [1.0, 1.0], decimal=5)
+
+    def test_normalization_logic_with_mocked_model(self):
+        """L2-normalization (incl. zero-vector guard) should run without the real model.
+
+        Keeps deterministic CI coverage of the numpy normalization path in
+        SentenceTransformerEmbedder.transform(); the real-model tests above are
+        opt-in (RUN_MODEL_TESTS=1), so this is the only default coverage of that block.
+        """
+        from src.dedup1_nb.embedders import SentenceTransformerEmbedder
+
+        embedder = SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2", normalize=True)
+        fake_model = MagicMock()
+        # Non-normalized rows, including a zero vector to exercise the divide-by-zero guard.
+        fake_model.encode.return_value = np.array([[3.0, 4.0, 0.0], [0.0, 0.0, 0.0]])
+        embedder._model = fake_model  # bypass lazy load -> no HuggingFace download
+        embedder._embedding_dim = 3
+
+        embeddings = embedder.transform(["text one", "text two"])
+
+        norms = np.linalg.norm(embeddings, axis=1)
+        # First row scaled to unit norm; zero row stays zero (guard prevents NaN).
+        np.testing.assert_array_almost_equal(norms, [1.0, 0.0], decimal=5)
+        np.testing.assert_array_almost_equal(embeddings[0], [0.6, 0.8, 0.0], decimal=5)
 
 
 class TestTfidfLsaEmbedder:
@@ -379,7 +436,7 @@ class TestTfidfLsaEmbedder:
 class TestDeduplicateArticles:
     """Tests for the production deduplicate_articles function."""
 
-    def test_returns_tuple(self):
+    def test_returns_tuple(self, patch_novelty_embedder):
         """Should return (articles, count) tuple."""
         # Create mock articles
         articles = []
@@ -390,7 +447,9 @@ class TestDeduplicateArticles:
             article.description = None
             articles.append(article)
 
-        result = deduplicate_articles(articles, similarity_threshold=0.99)
+        result = deduplicate_articles(
+            articles, similarity_threshold=0.99, require_label_match=False
+        )
 
         assert isinstance(result, tuple)
         assert len(result) == 2
@@ -415,7 +474,7 @@ class TestDeduplicateArticles:
 
         assert result == ([article], 0)
 
-    def test_removes_duplicates(self):
+    def test_removes_duplicates(self, patch_novelty_embedder):
         """Should remove duplicate articles."""
         # Create two articles with identical content
         article1 = MagicMock()
@@ -429,13 +488,13 @@ class TestDeduplicateArticles:
         article2.description = None
 
         deduplicated, removed = deduplicate_articles(
-            [article1, article2], similarity_threshold=0.75
+            [article1, article2], similarity_threshold=0.75, require_label_match=False
         )
 
         assert len(deduplicated) == 1
         assert removed == 1
 
-    def test_keeps_distinct_articles(self):
+    def test_keeps_distinct_articles(self, patch_novelty_embedder):
         """Should keep distinct articles."""
         article1 = MagicMock()
         article1.title = "Nike launches new running shoe"
@@ -448,10 +507,40 @@ class TestDeduplicateArticles:
         article2.description = None
 
         deduplicated, removed = deduplicate_articles(
-            [article1, article2], similarity_threshold=0.75
+            [article1, article2], similarity_threshold=0.75, require_label_match=False
         )
 
         # Different topics should be kept
+        assert len(deduplicated) == 2
+        assert removed == 0
+
+    def test_preserves_similar_articles_with_different_labels(self, patch_novelty_embedder):
+        """With require_label_match=True, similar articles with differing ESG labels are kept."""
+
+        def _make_article(title, content, label_pairs):
+            """Build a mock Article whose brand_labels yield the given (brand, category) pairs."""
+            article = MagicMock()
+            article.title = title
+            article.full_content = content
+            article.description = None
+            brand_label = MagicMock()
+            brand_label.brand = "Nike"
+            brand_label.evidence = [
+                MagicMock(category=category) for _, category in label_pairs
+            ]
+            article.brand_labels = [brand_label]
+            return article
+
+        # Identical text (cosine 1.0 >= threshold) but different ESG categories.
+        text = "Nike today announced a major sustainability initiative."
+        article1 = _make_article(text, text, [("Nike", "carbon_emissions")])
+        article2 = _make_article(text, text, [("Nike", "worker_rights")])
+
+        deduplicated, removed = deduplicate_articles(
+            [article1, article2], similarity_threshold=0.75, require_label_match=True
+        )
+
+        # Different labels mean the second article carries new ESG coverage -> preserved.
         assert len(deduplicated) == 2
         assert removed == 0
 


### PR DESCRIPTION
Fixes #47.

## Problem

`tests/test_deduplication.py` was the only test file that loaded the real `all-MiniLM-L6-v2` sentence-transformer model from HuggingFace Hub **at test time**. When the Hub rate-limited the runner (429), 5 tests failed with network errors unrelated to the code under test, making CI non-deterministic.

## Approach

Bring the file in line with the codebase's existing mocking pattern (`test_novelty.py` mocks `_sentence_model`; `test_reranker.py` patches `CrossEncoder`), splitting the failing tests by what they actually verify:

- **`TestDeduplicateArticles` (3 tests)** test dedup *logic*, not the model → patch `NoveltyScorer.embed_texts` with a deterministic offline stub.
- **`TestSentenceTransformerEmbedder` (2 tests)** genuinely assert the *real* model's 384-dim output and normalization → gate behind `RUN_MODEL_TESTS=1` (mirrors the existing `RUN_DB_TESTS` gate).

The design was reviewed by the architect agent ([review](https://github.com/frederick-douglas-pearce/sportswear-esg-news-classifier/issues/47#issuecomment-4727377115)); its refinements are incorporated.

## Changes

- **`tests/conftest.py`**: shared `fake_embed_texts` fixture — per-text seeded unit vectors (identical text → cosine 1.0, distinct → ~0). Provably correct (no hash-collision risk), reusable by future embedding tests.
- **`TestDeduplicateArticles`**: use the offline stub + pass `require_label_match=False` explicitly, removing the hidden coupling on bare `MagicMock` iterating empty.
- **New test** for the label-gate branch (similar articles with different ESG labels → preserved), previously uncovered.
- **`TestSentenceTransformerEmbedder`** real-model tests gated behind `RUN_MODEL_TESTS=1`.
- **New `test_normalization_logic_with_mocked_model`** keeps deterministic CI coverage of the embedder's numpy L2-normalize path (incl. zero-vector guard) now that the real-model tests are opt-in.
- **`CLAUDE.md`**: document `RUN_MODEL_TESTS` next to `RUN_DB_TESTS`; drop the stale hardcoded test count.

**CI YAML is unchanged** — leaving `RUN_MODEL_TESTS` unset keeps the main test job fully deterministic with zero HuggingFace dependency (chosen over a non-blocking cached real-model job).

## Test plan

- `uv run pytest tests/test_deduplication.py` → 41 passed, 2 skipped, **no network** (real-model tests skip).
- `RUN_MODEL_TESTS=1 uv run pytest tests/test_deduplication.py::TestSentenceTransformerEmbedder` → 3 passed (real model loads and asserts as before).
- Full suite: `uv run pytest` → 1268 passed, 26 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)