### PR TITLE
Bump GitHub Actions off deprecated Node 20 runtime (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           version: 'latest'
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: uv-${{ runner.os }}-
       - run: uv sync --frozen --extra dev
       - run: uv run pytest --tb=short --junitxml=junit.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
@@ -233,7 +233,7 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -35,15 +35,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: 'latest'
 
@@ -91,7 +91,7 @@ jobs:
             --verbose || echo "DRIFT_DETECTED=true" >> $GITHUB_OUTPUT
 
       - name: Upload monitoring reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: monitoring-reports-${{ matrix.classifier }}
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Download all reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: all-reports
 


### PR DESCRIPTION
Fixes #48.

## Problem

GitHub Actions runners are removing Node.js 20 (forced to Node 24 on **2026-06-16**, Node 20 removed **2026-09-16**). Every CI run emitted a deprecation warning for `actions/checkout@v4`, `actions/setup-python@v5`, `astral-sh/setup-uv@v4`, `actions/cache@v4`, `actions/upload-artifact@v4`.

## Changes

Each in-scope action bumped to a major that ships a Node 24 runtime — verified by reading `action.yml` (`using: node24`) at the target tag and checking each changelog for breaking input changes.

| Workflow | Action | From → To |
|---|---|---|
| `ci.yml` | checkout / setup-python / setup-uv / cache / upload-artifact | v4→**v6** / v5→**v6** / v4→**v7** / v4→**v5** / v4→**v7** |
| `deploy.yml` | checkout (×2) | v4→**v6** |
| `monitoring.yml` | checkout / setup-python / setup-uv / upload-artifact / download-artifact | v4→**v6** / v5→**v6** / v4→**v7** / v4→**v7** / v4→**v7** |

## Why not always the latest major

- **setup-uv → v7 (not v8):** v8 stopped publishing bare major/minor tags, which would force exact-version pinning (`@v8.2.0`) and break the major-tag convention used everywhere else. v7 runs Node 24 and keeps `version: latest` valid.
- **download-artifact → v7 (not v8):** v8 errors on hash mismatch by default and stops unzipping based on `Content-Type`, which risks the "download all artifacts" summary job. v7 is the first Node-24 major and pairs cleanly with `upload-artifact@v7`.

All other bumps (checkout v6, setup-python v6, cache v5, upload-artifact v7) are the latest majors; breaking changes there are runtime/credential internals that don't affect our bare/standard usage on current hosted runners.

**Out of scope** (not in the deprecation list, left unchanged): `google-github-actions/auth@v2`, `google-github-actions/setup-gcloud@v2`, `jlumbroso/free-disk-space`.

## Test plan

- All six target tags confirmed to exist as bare major tags and to run `node24` (via `action.yml` at each tag).
- YAML validated with `yaml.safe_load` for all three workflows.
- CI (`ci.yml`) runs on this PR and exercises checkout v6, setup-python v6, setup-uv v7, cache v5, upload-artifact v7 — green CI validates them end-to-end.
- `deploy.yml` (workflow_dispatch/call) and `monitoring.yml` (schedule/dispatch) do **not** run on PRs, so their bumped actions are validated by tag/runtime confirmation rather than execution. The changes there are limited to checkout + artifact version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)