### PR TITLE
Make agent runs DNS-resilient and surface notification failures (#51)

### DIFF
--- a/scripts/cron_agent.sh
+++ b/scripts/cron_agent.sh
@@ -27,11 +27,13 @@ echo "========================================" >> "$LOG_FILE"
 cd "$PROJECT_DIR"
 
 # Run agent workflow.
-# --frozen: run from the provisioned venv with no network resolution. Cron
-# fires in an early-morning window where DNS is intermittently down; without
-# this, uv re-fetches the direct-URL spaCy model dep from GitHub and aborts
-# before any Python runs. Fails loudly if the lockfile is stale. See issue #45.
-~/.local/bin/uv run --frozen python -m src.agent run "$WORKFLOW" >> "$LOG_FILE" 2>&1
+# --frozen --no-sync: run from the provisioned venv with zero network access.
+# Cron fires in an early-morning window where DNS is down for hours (the host
+# suspends overnight). --frozen alone is insufficient: uv still re-fetches
+# metadata for the direct-URL spaCy model dep from GitHub and aborts before any
+# Python runs (issue #51). --no-sync skips the env sync so uv never touches the
+# network. Fails loudly if the venv is missing. See issues #45 and #51.
+~/.local/bin/uv run --frozen --no-sync python -m src.agent run "$WORKFLOW" >> "$LOG_FILE" 2>&1
 EXIT_CODE=$?
 
 echo "" >> "$LOG_FILE"

--- a/scripts/cron_collect.sh
+++ b/scripts/cron_collect.sh
@@ -32,9 +32,10 @@ echo "========================================" >> "$LOG_FILE"
 # Use uv to run the script in the project's virtual environment
 # Default mode is brand-only queries (no keyword filtering)
 # Add --with-keywords to use the old brand + keyword combination queries
-# --frozen: no network resolution at run time so the early-morning cron run
-# does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
-~/.local/bin/uv run --frozen python scripts/collect_news.py \
+# --frozen --no-sync: zero network access at run time. --frozen alone still
+# lets uv re-fetch the direct-URL spaCy model metadata; --no-sync skips the env
+# sync so the early-morning cron run never touches DNS. See issues #45 and #51.
+~/.local/bin/uv run --frozen --no-sync python scripts/collect_news.py \
     --max-calls 50 \
     --scrape-limit 100 \
     >> "$LOG_FILE" 2>&1

--- a/scripts/cron_monitor.sh
+++ b/scripts/cron_monitor.sh
@@ -55,9 +55,10 @@ run_monitoring() {
     fi
 
     # Run monitoring script.
-    # --frozen: no network resolution at run time so the early-morning cron run
-    # does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
-    if uv run --frozen python scripts/monitor_drift.py $ARGS >> "$LOG_FILE" 2>&1; then
+    # --frozen --no-sync: zero network access at run time. --frozen alone still
+    # lets uv re-fetch the direct-URL spaCy model metadata; --no-sync skips the
+    # env sync so the early-morning cron run never touches DNS. See #45 and #51.
+    if uv run --frozen --no-sync python scripts/monitor_drift.py $ARGS >> "$LOG_FILE" 2>&1; then
         log "Drift monitoring completed successfully for $classifier"
         return 0
     else

--- a/scripts/cron_scrape.sh
+++ b/scripts/cron_scrape.sh
@@ -26,9 +26,10 @@ echo "GDELT collection started: $(date)" >> "$LOG_FILE"
 echo "========================================" >> "$LOG_FILE"
 
 # Use uv to run GDELT collection with 6-hour timespan
-# --frozen: no network resolution at run time so the early-morning cron run
-# does not fail re-fetching the direct-URL spaCy model dep. See issue #45.
-~/.local/bin/uv run --frozen python scripts/collect_news.py \
+# --frozen --no-sync: zero network access at run time. --frozen alone still
+# lets uv re-fetch the direct-URL spaCy model metadata; --no-sync skips the env
+# sync so the early-morning cron run never touches DNS. See issues #45 and #51.
+~/.local/bin/uv run --frozen --no-sync python scripts/collect_news.py \
     --source gdelt \
     --timespan 6h \
     --max-calls 50 \

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -255,12 +255,14 @@ def run_uv_script(
         ScriptResult with execution details
     """
     uv_path = _get_uv_path()
-    # --frozen: run from the already-provisioned venv with zero network
-    # resolution, and fail loudly if the lockfile is stale. Cron runs in an
-    # early-morning window where DNS is intermittently unavailable; without
-    # this, uv tries to re-fetch the direct-URL spaCy model dep from GitHub
-    # and aborts before any Python runs. See issue #45.
-    command = [uv_path, "run", "--frozen", "python", script_path]
+    # --frozen --no-sync: run from the already-provisioned venv with zero
+    # network access. Cron fires in an early-morning window where DNS is down
+    # for hours (host suspends overnight). --frozen alone is insufficient:
+    # uv still re-fetches metadata for the en-core-web-sm direct-URL wheel
+    # from GitHub and aborts before any Python runs (observed in issue #51).
+    # --no-sync skips the environment sync entirely so uv never resolves the
+    # network. See issues #45 and #51.
+    command = [uv_path, "run", "--frozen", "--no-sync", "python", script_path]
     if args:
         command.extend(args)
     return run_script(command, **kwargs)

--- a/src/agent/workflows/daily_labeling.py
+++ b/src/agent/workflows/daily_labeling.py
@@ -482,6 +482,22 @@ def send_notification(workflow: Workflow, context: dict[str, Any]) -> dict[str, 
     # Determine what channels were used
     channels_used = [k for k, v in result.items() if v]
 
+    # The whole purpose of this run is to deliver the morning report, so a run
+    # that could not deliver it must not report success. "console" is the
+    # no-channel-configured fallback (always succeeds) and is not a delivery
+    # failure. If real channels (email/webhook) were attempted and every one
+    # failed -- typically DNS/network down at cron time -- raise so the
+    # workflow is marked FAILED and surfaces in `agent status` and the cron
+    # exit code, instead of silently archiving as "completed". See issue #51.
+    attempted_channels = [k for k in result if k != "console"]
+    if attempted_channels and not channels_used:
+        raise RuntimeError(
+            "Notification delivery failed on all configured channels "
+            f"({', '.join(sorted(attempted_channels))}); the report was generated "
+            "and saved but not delivered. This is usually DNS/network being "
+            "unavailable at cron time."
+        )
+
     return {
         "notification_sent": len(channels_used) > 0,
         "channels": channels_used,

--- a/src/agent/workflows/model_training.py
+++ b/src/agent/workflows/model_training.py
@@ -585,8 +585,8 @@ def promote_model(workflow: Workflow, context: dict[str, Any]) -> dict[str, Any]
         # The notebooks have already trained the model, we just need to register it
         result = run_script(
             [
-                # --frozen: no network resolution at run time (see issue #45)
-                "uv", "run", "--frozen", "python", "scripts/register_model.py",
+                # --frozen --no-sync: zero network access (see issues #45, #51)
+                "uv", "run", "--frozen", "--no-sync", "python", "scripts/register_model.py",
                 "--classifier", classifier,
                 "--bump", "minor",  # Default to minor version bump
                 "--update-registry",

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -263,11 +263,14 @@ class TestRunUvScript:
             called_command = mock_run.call_args[0][0]
             # First element should be uv path (may be full path or just 'uv')
             assert called_command[0].endswith("uv")
-            # --frozen ensures cron runs use the provisioned venv with no
-            # network resolution (issue #45).
+            # --frozen --no-sync ensures cron runs use the provisioned venv with
+            # zero network access. --frozen alone still lets uv re-fetch the
+            # direct-URL spaCy model metadata; --no-sync skips the env sync so
+            # the early-morning cron run never touches DNS (issues #45, #51).
             assert called_command[1:] == [
                 "run",
                 "--frozen",
+                "--no-sync",
                 "python",
                 "scripts/test.py",
                 "--flag",

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -532,6 +532,56 @@ Errors (5):
         assert "error" not in llm
 
 
+class TestDailyLabelingSendNotification:
+    """Tests for the daily_labeling send_notification step (#51)."""
+
+    def _context(self):
+        return {
+            "report": {
+                "labeling": {"articles_processed": 3, "articles_labeled": 2},
+                "collection": {},
+                "quality": {},
+            }
+        }
+
+    def test_raises_when_all_configured_channels_fail(self):
+        """DNS down: email/webhook attempted and all fail -> raise so the run is FAILED."""
+        from src.agent.workflows.daily_labeling import send_notification
+
+        with patch(
+            "src.agent.notifications.send_labeling_summary",
+            return_value={"email": False, "webhook": False},
+        ):
+            with pytest.raises(RuntimeError, match="Notification delivery failed"):
+                send_notification(MagicMock(), self._context())
+
+    def test_does_not_raise_when_no_channels_configured(self):
+        """Console fallback (nothing configured) is not a delivery failure."""
+        from src.agent.workflows.daily_labeling import send_notification
+
+        with patch(
+            "src.agent.notifications.send_labeling_summary",
+            return_value={"console": True},
+        ):
+            result = send_notification(MagicMock(), self._context())
+
+        # Console fallback counts as delivered; the key point is it must not raise.
+        assert result["channels"] == ["console"]
+
+    def test_succeeds_when_one_channel_delivers(self):
+        """At least one real channel delivering is success."""
+        from src.agent.workflows.daily_labeling import send_notification
+
+        with patch(
+            "src.agent.notifications.send_labeling_summary",
+            return_value={"email": True, "webhook": False},
+        ):
+            result = send_notification(MagicMock(), self._context())
+
+        assert result["notification_sent"] is True
+        assert result["channels"] == ["email"]
+
+
 class TestWebsiteExportWorkflow:
     """Tests for WebsiteExportWorkflow."""
 


### PR DESCRIPTION
Fixes #51.

## Problem
The daily labeling summary email stopped arriving most mornings (delivered only 2 of the last 10 days). Investigation traced it to a **multi-hour early-AM DNS outage on the host** — the midnight collection run succeeds, but every run from ~06:00 through past 09:00 PDT fails with `Temporary failure in name resolution`. The machine almost certainly suspends overnight and the resolver/network does not recover promptly.

That single environmental issue broke the pipeline in three places, and a code gap hid it:
1. `uv run --frozen` still re-fetches metadata for the `en-core-web-sm` direct-URL wheel and aborts before any Python runs (despite the #45 mitigation).
2. Labeling API calls and the Resend email send both fail on name resolution.
3. The `send_notification` step swallowed the failure — the workflow archived as `completed` with `notification_sent: false`, so `agent status` looked clean.

## Changes
- **`--frozen --no-sync`** in `runner.py` and all cron wrappers (`cron_agent`, `cron_collect`, `cron_scrape`, `cron_monitor`) plus the `model_training` register step. `--no-sync` skips the environment sync entirely, so uv never resolves DNS at run time. Verified `uv run --frozen --no-sync` runs from the provisioned venv on uv 0.9.5.
- **Surface notification failures**: when every configured channel (email/webhook) fails to deliver, `send_notification` now raises → workflow marked `FAILED` → CLI exits non-zero. The no-channel `console` fallback is still treated as success.

## Not included (needs a decision)
The **durable fix is host-level**: reschedule the agent cron jobs out of the dead early-morning DNS window, or keep the host awake/networked overnight. No in-job retry helps when DNS is down for hours. Tracked as a follow-up in #51.

## Testing
- `uv run pytest` → 1271 passed, 26 skipped.
- Updated the uv-command assertion; added `send_notification` tests for delivery-failure (raises), console fallback (no raise), and partial success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)