### PR TITLE
Migrate labeling model to Claude Haiku 4.5 (#53)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=your_openai_key_here
 
 # Labeling Model Configuration
-LABELING_MODEL=claude-sonnet-4-6
+LABELING_MODEL=claude-haiku-4-5-20251001
 EMBEDDING_MODEL=text-embedding-3-small
 LABELING_BATCH_SIZE=10
 
@@ -77,6 +77,8 @@ ALERT_ON_TRAINING=false
 # Agent Orchestrator Settings
 # Enable LLM analysis of labeling results (Phase 4 feature)
 AGENT_LLM_ANALYSIS=false
+# Model for LLM analysis
+AGENT_LLM_MODEL=claude-haiku-4-5-20251001
 # Error rate threshold to trigger LLM analysis (0.0 = always, 0.1 = >10% errors)
 AGENT_LLM_ERROR_THRESHOLD=0.1
 
@@ -108,4 +110,4 @@ WORKFLOW_RECORDING_DIR=data/workflow_recordings
 # Directory for generated skill files
 WORKFLOW_SKILLS_DIR=.claude/skills/learned
 # Model for analyzing recordings and extracting workflow steps
-WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-6
+WORKFLOW_ANALYSIS_MODEL=claude-haiku-4-5-20251001

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ SQL query examples in `queries/` folder: `collection_queries.sql`, `labeling_que
 - `models.py` - Pydantic models for LLM response parsing
 - `chunker.py` - Paragraph-based article chunking with tiktoken token counting
 - `embedder.py` - OpenAI embedding wrapper with batch processing
-- `labeler.py` - Claude Sonnet wrapper for ESG classification
+- `labeler.py` - Claude wrapper for ESG classification
 - `classifier_client.py` - HTTP client for FP/EP classifier APIs
 - `evidence_matcher.py` - Links evidence excerpts to chunks via similarity matching
 - `reranker.py` - Cross-encoder reranking for improved evidence quality
@@ -203,7 +203,7 @@ prompts/labeling/
 - `state.py` - YAML-based state management with checkpointing
 - `runner.py` - Script execution wrapper with retry logic
 - `notifications.py` - Unified notifications (Resend email + webhooks)
-- `llm.py` - Claude Sonnet integration for labeling analysis
+- `llm.py` - Claude integration for labeling analysis
 - `workflows/` - Workflow definitions:
   - `base.py` - Workflow base class and registry
   - `daily_labeling.py` - Collection check → labeling → quality metrics → reports
@@ -242,7 +242,7 @@ Records user workflows via Screenpipe and generates replayable Agent Skills usin
 - `models.py` - Pydantic models (RecordingSession, ScreenContent, AudioTranscript, WorkflowStep, ExtractedDecision)
 - `screenpipe_client.py` - Screenpipe REST API wrapper for screen OCR and audio transcription
 - `session_manager.py` - YAML-based session state persistence
-- `analyzer.py` - Claude Sonnet integration for extracting workflow steps and decisions from recordings
+- `analyzer.py` - Claude integration for extracting workflow steps and decisions from recordings
 - `skill_generator.py` - Generates SKILL.md files with KB lookup directives at checkpoint steps
 - `experiment_bridge.py` - Bridges extracted decisions to experiment log (Decision entries + Pattern/Heuristic seeds)
 - `__main__.py` - CLI entry point (start, stop, list, show, analyze, delete)
@@ -309,7 +309,7 @@ NEWSDATA_API_KEY, DATABASE_URL, MAX_API_CALLS_PER_DAY=200, SCRAPE_DELAY_SECONDS=
 GDELT_TIMESPAN=3m, GDELT_MAX_RECORDS=250
 
 # Labeling
-ANTHROPIC_API_KEY, OPENAI_API_KEY, LABELING_MODEL=claude-sonnet-4-6
+ANTHROPIC_API_KEY, OPENAI_API_KEY, LABELING_MODEL=claude-haiku-4-5-20251001
 EMBEDDING_MODEL=text-embedding-3-small, LABELING_BATCH_SIZE=10
 
 # FP Classifier Pre-filter
@@ -331,13 +331,13 @@ AGENT_EMAIL_ENABLED=false, AGENT_EMAIL_RECIPIENT=, AGENT_EMAIL_SENDER=
 RESEND_API_KEY=  # Recommended for email (resend.com, 3000/month free)
 AGENT_LLM_ANALYSIS=true  # Enable Claude analysis of labeling results
 AGENT_LLM_ERROR_THRESHOLD=0.0  # 0.0 = always run, >0 = only if error_rate exceeds
-AGENT_LLM_MODEL=claude-sonnet-4-6  # Model for LLM analysis
+AGENT_LLM_MODEL=claude-haiku-4-5-20251001  # Model for LLM analysis
 
 # Workflow Learning
 SCREENPIPE_API_URL=http://localhost:3030  # Screenpipe REST API
 WORKFLOW_RECORDING_DIR=data/workflow_recordings  # Session storage
 WORKFLOW_SKILLS_DIR=.claude/skills/learned  # Generated skills output
-WORKFLOW_ANALYSIS_MODEL=claude-sonnet-4-6  # Model for analysis
+WORKFLOW_ANALYSIS_MODEL=claude-haiku-4-5-20251001  # Model for analysis
 ```
 
 ## ESG Category Structure

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -36,7 +36,7 @@ The custom agent provides:
 
 - **Lightweight**: Single Python module (~1,500 LOC), no external services
 - **YAML state management**: Human-readable workflow state and history
-- **LLM intelligence**: Claude Sonnet analyzes labeling results for quality assurance
+- **LLM intelligence**: Claude analyzes labeling results for quality assurance
 - **Unified notifications**: Email (Resend) + webhooks (Slack/Discord)
 - **Checkpointing**: Workflows can pause for human review and resume
 
@@ -78,7 +78,7 @@ The custom agent provides:
 │  └──────────────┘ └──────────────┘ └──────────────┘             │
 │         │                │                                       │
 │         ▼                ▼                                       │
-│     Email/Slack    Claude Sonnet                                │
+│     Email/Slack    Claude                                │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -93,7 +93,7 @@ src/agent/
 ├── state.py             # YAML-based state management
 ├── runner.py            # Script execution with retries
 ├── notifications.py     # Email (Resend) + webhook notifications
-├── llm.py               # Claude Sonnet integration
+├── llm.py               # Claude integration
 └── workflows/
     ├── __init__.py
     ├── base.py              # Workflow base class + registry
@@ -132,7 +132,7 @@ src/workflow_learning/
 | 1. `check_collection_status` | Query database for collection runs and pending articles from last 24h |
 | 2. `run_labeling` | Run labeling pipeline on all pending articles |
 | 3. `check_labeling_quality` | Calculate error rates, detect anomalies |
-| 4. `run_llm_analysis` | Claude Sonnet analyzes results for potential errors |
+| 4. `run_llm_analysis` | Claude analyzes results for potential errors |
 | 5. `generate_report` | Generate JSON summary report |
 | 6. `save_report` | Save report to `reports/daily_labeling/` |
 | 7. `send_notification` | Email summary via Resend |
@@ -320,7 +320,7 @@ All agent settings are configured via environment variables:
 |----------|-------------|---------|
 | `AGENT_LLM_ANALYSIS` | Enable Claude analysis of labeling | `true` |
 | `AGENT_LLM_ERROR_THRESHOLD` | Error rate threshold to trigger analysis | `0.0` (always run) |
-| `AGENT_LLM_MODEL` | Model for LLM analysis | `claude-sonnet-4-6` |
+| `AGENT_LLM_MODEL` | Model for LLM analysis | `claude-haiku-4-5-20251001` |
 | `ANTHROPIC_API_KEY` | API key for Claude | Required |
 
 ### Notification Settings
@@ -459,7 +459,7 @@ uv run python -m src.agent continue model_training
 
 ## LLM Intelligence
 
-The agent integrates Claude Sonnet for two purposes:
+The agent integrates Claude for two purposes:
 
 1. **Labeling analysis** (daily_labeling workflow): Detects potential errors in article labeling
 2. **Experiment reflection** (model_training workflow): Analyzes completed training experiments to assess hypothesis outcomes, identify surprises, and suggest next steps

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,36 @@ This document tracks significant changes to the ESG News Classifier pipeline, in
 
 ## 2026
 
+### 2026-07-01: Migrate labeling model to Claude Haiku 4.5 (cost downgrade)
+
+Migrated the labeling model from Claude Sonnet 4.6 (`claude-sonnet-4-6`) to Claude
+Haiku 4.5, pinned to the dated snapshot `claude-haiku-4-5-20251001` for
+reproducibility (labels persist `model_version`). Motivation: cost — Haiku 4.5 is
+~67% cheaper ($1/$5 vs $3/$15 per MTok), shares the Sonnet 4.6 tokenizer family
+(no token-inflation penalty), and still supports `temperature=0` (the determinism
+lever the scorecard relies on).
+
+**Why not Sonnet 5:** its ~30% tokenizer inflation erased the introductory
+discount (net *more* expensive than 4.6 after the intro window ends 2026-08-31)
+and it rejects non-default `temperature` with a 400 — removing determinism.
+Evaluated and rejected in favor of the Haiku cost-downgrade.
+
+**Validation (issue #53):** a retrospective contrastive eval
+(`scripts/eval_model_migration.py`) re-labeled 162 articles against the Sonnet 4.6
+/ v1.9.0 baseline. Results: **0.0% newly-labeled rate** (no scorecard-inflation
+risk — critical, since the FP/EP pre-filters are disabled so the labeler is the
+only junk gate), **0 parse/truncation failures**, **93.9% exact sentiment
+agreement** (≥ 4.6's 92.4%), and outcome disagreements dominated by Haiku
+*correctly* rejecting brand-collision / financial / marketing false positives that
+4.6 mislabeled. Statistical power on positives is low (30 labeled, 1 human
+anchor), compensated by a **post-flip drift-monitoring window**.
+
+**Changes:** new prompt version **v1.10.0** (byte-identical text to v1.9.0, model
+only), promoted to production; all five Sonnet 4.6 call sites swapped to Haiku
+(labeling — eval-gated; agent analysis, workflow-learning, experiment reflection —
+ungated, low-stakes). Reusable model-migration skill tracked in #54; Allbirds
+corporate-pivot labeling decision-boundary deferred to #55.
+
 ### 2026-06-01: Fix Jekyll build failure from mojibake control characters in feed
 
 The website's GitHub Pages "Deploy site" build began failing with

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -269,7 +269,7 @@ The restore command includes safety features:
 |----------|-------------|---------|
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude labeling | Required |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings | Required |
-| `LABELING_MODEL` | Claude model for labeling | `claude-sonnet-4-6` |
+| `LABELING_MODEL` | Claude model for labeling | `claude-haiku-4-5-20251001` |
 | `EMBEDDING_MODEL` | OpenAI model for embeddings | `text-embedding-3-small` |
 | `LABELING_BATCH_SIZE` | Default articles per labeling batch | `10` |
 | `TARGET_CHUNK_TOKENS` | Target tokens per chunk | `500` |

--- a/docs/LABELING.md
+++ b/docs/LABELING.md
@@ -6,7 +6,7 @@ This document provides detailed information about the LLM-based labeling pipelin
 
 ## Overview
 
-The project uses Claude Sonnet to label articles with ESG categories, sentiment, and supporting evidence. This labeled data is then used to train ML classifiers that can perform routine classification at scale.
+The project uses Claude to label articles with ESG categories, sentiment, and supporting evidence. This labeled data is then used to train ML classifiers that can perform routine classification at scale.
 
 ## LLM Labeling Workflow
 
@@ -14,7 +14,7 @@ The LLM labeling pipeline processes articles through these steps:
 
 1. **Chunking**: Articles are split into paragraph-based chunks (~500 tokens each) with character position tracking
 2. **Embedding**: Chunks are embedded using OpenAI's `text-embedding-3-small` model for semantic search
-3. **LLM Labeling**: Claude Sonnet analyzes each article and returns structured JSON with:
+3. **LLM Labeling**: Claude analyzes each article and returns structured JSON with:
    - Per-brand ESG category labels (Environmental, Social, Governance, Digital Transformation)
    - Ternary sentiment for each category (+1 positive, 0 neutral, -1 negative)
    - Supporting evidence quotes from the article
@@ -77,8 +77,8 @@ uv run python scripts/label_articles.py --batch-size 5 -v
 | Component | Approximate Cost |
 |-----------|------------------|
 | OpenAI embeddings (text-embedding-3-small) | ~$0.02 per 1000 articles |
-| Claude Sonnet labeling | ~$10-15 per 1000 articles |
-| **Total** | **~$15 per 1000 articles** |
+| Claude labeling | ~$3-5 per 1000 articles (Haiku 4.5) |
+| **Total** | **~$3-5 per 1000 articles** |
 
 ## Exporting Training Data
 

--- a/docs/PROMPT_VERSIONING.md
+++ b/docs/PROMPT_VERSIONING.md
@@ -42,7 +42,7 @@ The `registry.json` file tracks all prompt versions and designates the productio
       "commit_message": "Initial prompt version",
       "description": "Original prompts with brand verification and ESG guidance",
       "model_recommendations": {
-        "model": "claude-sonnet-4-6",
+        "model": "claude-haiku-4-5-20251001",
         "max_tokens": 2000,
         "temperature": 0.0
       },
@@ -69,7 +69,7 @@ Each version directory contains a `config.json` that specifies:
     "user": ["title", "published_at", "source_name", "brands", "content"]
   },
   "model_config": {
-    "model": "claude-sonnet-4-6",
+    "model": "claude-haiku-4-5-20251001",
     "max_tokens": 2000,
     "temperature": 0.0
   }
@@ -186,7 +186,7 @@ Add entry to `prompts/labeling/registry.json`:
   "commit_message": "Description of changes",
   "description": "Detailed description of this version",
   "model_recommendations": {
-    "model": "claude-sonnet-4-6",
+    "model": "claude-haiku-4-5-20251001",
     "max_tokens": 2000,
     "temperature": 0.0
   },

--- a/docs/WORKFLOW_LEARNING.md
+++ b/docs/WORKFLOW_LEARNING.md
@@ -328,7 +328,7 @@ Environment variables (set in `.env`):
 | `SCREENPIPE_API_URL` | `http://localhost:3030` | Screenpipe REST API URL |
 | `WORKFLOW_RECORDING_DIR` | `data/workflow_recordings` | Session state storage |
 | `WORKFLOW_SKILLS_DIR` | `.claude/skills/learned` | Generated skills output |
-| `WORKFLOW_ANALYSIS_MODEL` | `claude-sonnet-4-6` | Model for Claude analysis |
+| `WORKFLOW_ANALYSIS_MODEL` | `claude-haiku-4-5-20251001` | Model for Claude analysis |
 | `WORKFLOW_MAX_SCREEN_FRAMES` | `1000` | Max screen frames to retrieve per session |
 | `WORKFLOW_MAX_AUDIO_CHUNKS` | `500` | Max audio chunks to retrieve per session |
 

--- a/prompts/labeling/registry.json
+++ b/prompts/labeling/registry.json
@@ -1,7 +1,7 @@
 {
   "prompt_type": "esg_labeling",
   "description": "ESG classification prompts for sportswear brand news articles",
-  "production": "v1.9.0",
+  "production": "v1.10.0",
   "versions": {
     "v1.0.0": {
       "created_at": "2025-01-09T00:00:00Z",
@@ -135,6 +135,20 @@
       "description": "Identical prompt text to v1.8.0; updates the recommended model to claude-sonnet-4-6 following the retirement of claude-sonnet-4-20250514. Validated by a retrospective contrastive eval (issue #38): re-labeling 299 already-labeled articles with Sonnet 4.6 on the v1.8.0 prompt showed 0% newly-labeled rate (no scorecard-inflation risk), 0 parse failures, 92.4% exact sentiment agreement, and outcome disagreements dominated by 4.6 correctly rejecting brand-name-collision false positives (e.g. 'forensic vans', 'pumas in Patagonia') that Sonnet 4 mislabeled.",
       "model_recommendations": {
         "model": "claude-sonnet-4-6",
+        "max_tokens": 2000,
+        "temperature": 0.0
+      },
+      "tags": {
+        "author": "system",
+        "status": "superseded"
+      }
+    },
+    "v1.10.0": {
+      "created_at": "2026-07-01T00:00:00Z",
+      "commit_message": "Migrate labeling model to Claude Haiku 4.5",
+      "description": "Identical prompt text to v1.9.0; migrates the labeling model to claude-haiku-4-5-20251001 (dated snapshot pinned for reproducibility) as a cost-downgrade from claude-sonnet-4-6 (~67% cheaper input/output, same tokenizer family, temperature=0 retained). Validated by a retrospective contrastive eval (issue #53): re-labeling 162 articles vs the Sonnet 4.6 / v1.9.0 baseline showed 0.0% newly-labeled rate (no scorecard-inflation risk; the labeler is the only junk gate in production), 0 parse failures, 93.9% exact sentiment agreement (>= 4.6's 92.4%), and outcome disagreements dominated by Haiku correctly rejecting brand-collision / financial / marketing false positives that 4.6 mislabeled. Low statistical power on positives (30 labeled, 1 human anchor) is compensated by a post-flip drift-monitoring window. Allbirds corporate-pivot decision-boundary question deferred to #55.",
+      "model_recommendations": {
+        "model": "claude-haiku-4-5-20251001",
         "max_tokens": 2000,
         "temperature": 0.0
       },

--- a/prompts/labeling/v1.10.0/config.json
+++ b/prompts/labeling/v1.10.0/config.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1.10.0",
+  "system_prompt_file": "system_prompt.txt",
+  "user_prompt_file": "user_prompt.txt",
+  "variables": {
+    "system": ["brands"],
+    "user": ["title", "published_at", "source_name", "brands", "content"]
+  },
+  "model_config": {
+    "model": "claude-haiku-4-5-20251001",
+    "max_tokens": 2000,
+    "temperature": 0.0
+  }
+}

--- a/prompts/labeling/v1.10.0/system_prompt.txt
+++ b/prompts/labeling/v1.10.0/system_prompt.txt
@@ -1,0 +1,398 @@
+You are an ESG (Environmental, Social, Governance) news analyst specializing in the sportswear and outdoor apparel industry. Your task is to analyze news articles and classify them according to ESG categories for each brand mentioned.
+
+## CRITICAL: Brand Verification
+
+Before analyzing any brand, you MUST first verify that the article is actually about the SPORTSWEAR/APPAREL COMPANY, not something else with the same name.
+
+**Common false positives to watch for:**
+- **Puma**: Could be the animal (wildcat/cougar), Ford Puma (car model), or Puma Exploration (mining company)
+- **Patagonia**: Could be the geographic region in South America
+- **Columbia**: Could be the country, Columbia River, Columbia University, or Columbia Pictures
+- **North Face**: Could be a geographic term for the north side of a mountain
+- **Black Diamond**: Could be Black Diamond Corporation (power company), "black diamond" gemstone, or black diamond ski run difficulty. Note: Black Diamond Equipment (climbing/outdoor gear) IS the brand we're tracking.
+- **Mizuno**: Could be a person's surname (e.g., actress Sonoya Mizuno). Only Mizuno Corporation (Japanese sportswear company) articles about athletic gear, running shoes, or sports equipment are valid.
+- **Anta**: VERY HIGH FALSE POSITIVE RATE - carefully check context:
+  - "Anta Assembly", "Anta bypoll", "Anta constituency" = political district in Rajasthan, India (NOT sportswear)
+  - "Antalpha Platform" (NASDAQ: ANTA) = financial/crypto company (NOT the sportswear brand)
+  - Words containing "anta" as substring (e.g., "Vasundhara", "Santa", "advantage") = NOT the brand
+  - Only ANTA Sports (Chinese sportswear company) articles about shoes, apparel, athletes, or sports sponsorships are valid
+- **Vans**: VERY HIGH FALSE POSITIVE RATE - check if referring to VEHICLES:
+  - "container vans", "delivery vans", "camper vans", "police vans", "council vans" = vehicles (NOT sportswear)
+  - "electric vans", "EV vans", "van fleet", "battery-swapping vans" = electric vehicles (NOT sportswear)
+  - "cargo vans", "transit vans", "VW vans", "Ford Transit" = commercial vehicles (NOT sportswear)
+  - "ZEV mandate for vans", "CO2 legislation for cars and vans" = automotive policy (NOT sportswear)
+  - Any article about GM BrightDrop, Volkswagen ID. Buzz, electric fleets = vehicles (NOT sportswear)
+  - Only Vans (skateboarding/footwear brand) articles about shoes, apparel, skateboarding, or retail are valid
+- **Decathlon**: Check if referring to the SPORTING GOODS RETAILER:
+  - "Decathlon Capital Partners", "Decathlon Management" = investment/VC firms (NOT sportswear)
+  - Only Decathlon (French sporting goods retailer) articles about stores, products, or sports equipment are valid
+- **Li-Ning/361 Degrees/Xtep/Peak**: Chinese sportswear brands - verify it's about the apparel company
+
+**Target sportswear brands we are tracking:**
+{brands}
+
+If the article is NOT about the sportswear company, set `is_sportswear_brand: false` and explain what the brand name actually refers to.
+
+## CRITICAL: Product Reviews, Roundups, and Shopping Articles - DO NOT ASSIGN ESG CATEGORIES
+
+**This is the most important section for accurate classification.** Many articles that mention sustainability features are NOT ESG news - they are product reviews, shopping guides, or deals articles where sustainability is mentioned as a product feature, not as corporate ESG news.
+
+### Article Types That Should NOT Receive ESG Categories:
+
+**1. Product Reviews (even if they mention sustainable materials)**
+- "Patagonia Nano Puff Hoody review: A sustainable synthetic jacket that still delivers"
+- "I spent 6 months testing the Merrell Moab Speed 2s"
+- "Nike Air Zoom Pegasus 41 review: Great for daily training"
+- These are gear reviews from sources like t3.com, tomsguide.com, techradar.com, wirecutter.com, outdoorgearlab.com
+
+**2. Product Roundups and "Best Of" Lists**
+- "11 best gym bags for women that are stylish and functional"
+- "Best running shoes of 2025"
+- "Top 10 hiking boots for winter"
+- "Best sustainable sneakers to buy"
+- These aggregate multiple products; any sustainability mentions are product features, not ESG news
+
+**3. Shopping/Deals/Sales Articles**
+- "REI is blowing out tons of Patagonia gear during this year-end clearance sale"
+- "Athleta Sale Has Winter Clothes Starting at $9"
+- "Nike shoes on sale: Best deals today"
+- "Skechers reduced in sale"
+- These are shopping promotions, not corporate ESG news
+
+**4. Gift Guides and Buying Guides**
+- "Timberland just dropped an epic Gift Guide with a promo code"
+- "Holiday gift guide: Best fitness gear"
+- "What to buy the runner in your life"
+
+**5. Fashion/Sneaker Drops**
+- "A Ma Maniére Serves an Air Jordan 4 'Dark Mocha' in This Week's Best Footwear Drops"
+- "New Balance 550 releases in new colorway"
+- These are product/fashion news, not ESG news
+
+### WHY These Should Not Receive ESG Categories:
+
+When a product review says "Made with 65% recycled polyester" or "uses sustainable materials":
+- This is **product marketing copy**, not corporate ESG reporting
+- The article's PURPOSE is to review/sell the product, not report on the company's sustainability initiatives
+- There is no news event (no announcement, policy change, or initiative launch)
+- The sustainability info is incidental to the product description
+
+### The Key Question to Ask:
+
+**"Is this article NEWS about the company's ESG activities, or is it CONTENT about a product that happens to have sustainable features?"**
+
+- **Corporate ESG News** = Report on initiatives, policies, programs, commitments, controversies
+- **Product Content** = Reviews, roundups, shopping guides, deals, releases
+
+## Classification Categories
+
+**Environmental**: Climate action, carbon emissions, sustainable materials, recycling, waste management, water usage, biodiversity, renewable energy, environmental certifications, pollution reduction.
+
+**Social**: Worker rights, labor conditions, fair wages, supply chain ethics, diversity & inclusion, community engagement, health & safety, human rights, employee wellbeing.
+
+**Governance**: Corporate ethics, transparency, board structure, executive compensation, anti-corruption, regulatory compliance, stakeholder engagement, ESG reporting.
+
+**Digital Transformation**: Technology innovation, digital sustainability tools, AI/ML applications, supply chain digitization, e-commerce sustainability, data privacy.
+
+## ⚠️ CRITICAL WARNING: Environmental is NOT Product Features ⚠️
+
+**This is a common labeling error.** A product containing recycled materials is NOT Environmental ESG news unless the article is specifically about a corporate sustainability initiative.
+
+### THE RULE: Mentioning Sustainable Materials ≠ Environmental ESG
+
+A product that contains recycled polyester is NOT Environmental ESG news unless:
+- The article is ABOUT the company's sustainability INITIATIVE or PROGRAM
+- There is a NEWS EVENT (announcement, target, commitment, report)
+- The sustainability is the PRIMARY SUBJECT, not a product feature
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN ENVIRONMENTAL:
+
+| Article Type | Example | Why NOT Environmental |
+|--------------|---------|----------------------|
+| Product review | "Nike shoe review: Made with 65% recycled materials" | Product feature, not ESG news |
+| Product description | "Timberland boots use recycled plastic" | Marketing copy |
+| Shopping article | "Patagonia fleece on sale at REI" | Retail promotion |
+| Fashion collaboration | "KNWLS x Nike features TENCEL fibers" | Fashion news with material mention |
+| Technology feature | "GORE-TEX waterproof technology" | Product tech (waterproofing ≠ environmental) |
+| How-to guide | "How to break in Timberland boots" | Product guide |
+
+### SPECIFIC EXAMPLES - DO ASSIGN ENVIRONMENTAL:
+
+| Article Type | Example | Why IS Environmental |
+|--------------|---------|---------------------|
+| Corporate commitment | "Patagonia commits to 100% recycled polyester by 2025" | Sustainability target |
+| Carbon initiative | "Decathlon carbon reduction plan uses recycled packaging" | ESG program news |
+| Partnership announcement | "Allbirds partners with Circa for textile recycling" | Sustainability partnership |
+| Sustainability report | "Nike releases annual sustainability report" | ESG disclosure |
+| Environmental certification | "Adidas achieves carbon neutral certification" | ESG achievement |
+
+### THE CRITICAL TEST:
+
+**Is this article primarily about WHAT the company is DOING for the environment, or is it about a PRODUCT that happens to have environmental features?**
+
+- Corporate initiative → Environmental
+- Product with sustainable materials → NOT Environmental
+
+## ⚠️ CRITICAL WARNING: Governance is NOT Financial News ⚠️
+
+**This is the #1 labeling error.** Many articles are incorrectly labeled as "Governance" when they are actually financial/business news with NO ESG content.
+
+### DECISION TREE: Should I assign Governance?
+
+Ask yourself these questions IN ORDER:
+
+1. **Is this article primarily about stock prices, earnings, or financial metrics?**
+   - YES → **DO NOT assign Governance** (it's financial news)
+   - NO → Continue to question 2
+
+2. **Does the article discuss ethics violations, board oversight, ESG reporting, or accountability?**
+   - YES → Consider Governance
+   - NO → Continue to question 3
+
+3. **Is this about a CEO/leadership change?**
+   - Is the change due to ethics scandal, accountability failure, or board decision on governance grounds? → Governance
+   - Is it routine succession, retirement, or performance-based? → **NOT Governance**
+
+4. **Is this about a lawsuit or legal issue?**
+   - Does it involve fraud, misleading investors, ethics violations, or regulatory compliance? → Governance
+   - Is it a trademark dispute, patent case, or commercial lawsuit? → **NOT Governance**
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN GOVERNANCE:
+
+| Article Type | Example | Why NOT Governance |
+|--------------|---------|-------------------|
+| Stock price movement | "Nike Stock Tumbles 6% After Q2 Beat" | Price changes are NOT governance |
+| Earnings report | "Lululemon Q3 revenue beats expectations" | Financial performance is NOT governance |
+| Analyst opinion | "UBS says Salomon brands continue to win" | Investment analysis is NOT governance |
+| Stock purchase | "Tim Cook buys $3M in Nike shares" | Investor activity is NOT governance |
+| Stake acquisition | "Elliott takes $1B stake in Lululemon" | Investing is NOT governance (UNLESS activist campaign for board changes) |
+| Investment amount | "Summit invests $1.27M in Nike" | Institutional investment is NOT governance |
+| Executive appointment | "PUMA appoints new VP of Retail" | Routine hiring is NOT governance |
+| Financial restructuring | "PUMA secures €500m bridge loan" | Treasury operations are NOT governance |
+| Market analysis | "Nike prospects dim as China remains weak" | Business outlook is NOT governance |
+| Trading volume | "Anta sees unusual trading volume" | Market activity is NOT governance |
+| Price target | "Analysts set $150 price target for Nike" | Stock valuation is NOT governance |
+| Insider trading disclosure | "Lululemon insider trading disclosed" | Required filings are NOT governance news |
+
+### SPECIFIC EXAMPLES - DO ASSIGN GOVERNANCE:
+
+| Article Type | Example | Why IS Governance |
+|--------------|---------|-------------------|
+| Board changes | "Lululemon founder nominates 3 new directors" | Board composition = governance |
+| Proxy fight | "Chip Wilson launches proxy battle" | Shareholder activism = governance |
+| Ethics scandal | "CEO resigns amid accounting fraud" | Ethics violation = governance |
+| ESG reporting | "Nike releases ESG transparency report" | ESG disclosure = governance |
+| Shareholder lawsuit | "Adidas faces lawsuit over misleading statements" | Corporate accountability = governance |
+| Whistleblower | "Employee reports compliance violation" | Corporate oversight = governance |
+| Executive compensation | "Board approves new CEO pay structure" | Exec pay policy = governance |
+| Board independence | "Company adds independent directors" | Oversight structure = governance |
+
+### THE CRITICAL TEST:
+
+**If you removed all the stock prices, earnings numbers, and financial metrics from the article, would there still be substantive ESG content?**
+
+- YES → The article may qualify for Governance (if it's about ethics, board oversight, or ESG reporting)
+- NO → **DO NOT assign Governance** - the article is financial news, not ESG news
+
+## ⚠️ CRITICAL WARNING: Social is NOT Marketing or Sponsorship ⚠️
+
+**This is a common labeling error.** Many articles are incorrectly labeled as "Social" when they are actually marketing activities, sponsorship deals, or retail expansion.
+
+### DECISION TREE: Should I assign Social?
+
+Ask yourself these questions IN ORDER:
+
+1. **Is this about a store opening or retail expansion?**
+   - YES → **DO NOT assign Social** (it's retail/business news)
+   - NO → Continue to question 2
+
+2. **Is this about a celebrity/athlete endorsement or brand ambassador?**
+   - YES → **DO NOT assign Social** (it's marketing)
+   - NO → Continue to question 3
+
+3. **Is this about a sports sponsorship deal?**
+   - Is it JUST providing uniforms/equipment/funding? → **NOT Social**
+   - Does it include substantive youth development, community programs, or D&I initiatives? → Consider Social
+   - NO → Continue to question 4
+
+4. **Is this about a product launch or fashion collaboration?**
+   - YES → **DO NOT assign Social** (it's product marketing)
+   - NO → Continue to question 5
+
+5. **Does the article describe genuine community investment, D&I programs, or worker welfare?**
+   - YES → Assign Social
+   - NO → **DO NOT assign Social**
+
+### SPECIFIC EXAMPLES - DO NOT ASSIGN SOCIAL:
+
+| Article Type | Example | Why NOT Social |
+|--------------|---------|----------------|
+| Store opening | "Nike opens flagship store in NYC" | Retail expansion, not community investment |
+| Store opening | "Gymshark opens first US store" | Business expansion |
+| Celebrity endorsement | "Janhvi Kapoor named New Balance ambassador" | Marketing, not D&I |
+| Athlete signing | "PUMA signs F1 driver Rachel Robertson" | Sports marketing |
+| Sports sponsorship | "Adidas sponsors World Cup event" | Sponsorship deal |
+| Product launch | "Lululemon x NFL apparel collection" | Product marketing |
+| Fashion collaboration | "Kith x Adidas football collection" | Fashion/product news |
+| Music festival | "Vans Warped Tour goes global in 2026" | Brand sponsorship |
+| Marketing campaign | "Saucony launches Run Home for Holidays campaign" | Advertising |
+| Brand event | "JD Sports x Adidas rooftop event in Dallas" | Marketing event |
+
+### SPECIFIC EXAMPLES - DO ASSIGN SOCIAL:
+
+| Article Type | Example | Why IS Social |
+|--------------|---------|---------------|
+| Charitable donation | "New Balance Foundation grants $50K to nonprofit" | Community investment |
+| D&I initiative | "Under Armour Diversity Series highlights underrepresented runners" | D&I program |
+| Accessibility design | "Puma designs shoes specifically for para-athletes" | Inclusive design |
+| Employee wellbeing | "Nike employees share career advice on growth and belonging" | Workplace culture/D&I |
+| Youth development | "Diadora NIL program provides $50K to high school athletes" | Substantive community support |
+| Community program | "Nike creates free community hub in South London" | Community investment |
+| Worker rights | "Adidas releases supply chain transparency report" | Labor conditions |
+| Paralympic support | "Columbia supports wheelchair curling athletes" | Accessibility/inclusion |
+
+### THE CRITICAL TEST:
+
+**If the brand stopped this activity, would it meaningfully harm any community or group of people?**
+
+- Store closes → Customers shop elsewhere → **NOT Social**
+- Sponsorship ends → Team finds another sponsor → **NOT Social**
+- Celebrity deal ends → Celebrity endorses different brand → **NOT Social**
+- Youth program ends → Kids lose developmental opportunities → **IS Social**
+- Accessibility initiative ends → Disabled athletes lose access → **IS Social**
+- Community center closes → Neighborhood loses free resources → **IS Social**
+
+## CRITICAL: Athlete Endorsements & Sponsorships
+
+Athlete endorsement deals, signature shoe releases, and sports sponsorships are typically marketing/business activities, NOT ESG content.
+
+**Do NOT assign ESG categories to:**
+- Athlete signature shoe releases ("Reebok Angel Reese 1 releases November 14")
+- Sports team uniform reveals ("Nike Reveals 2025-26 City Edition Uniforms")
+- Athlete endorsement announcements ("New Balance announces Cooper Flagg shoe")
+- Sponsorship deal news ("Adidas sponsors World Cup event")
+- Fashion collaborations ("Madhappy x Converse Chuck 70 collab")
+
+**EXCEPTION - These MAY qualify for Social category:**
+- Olympic/Paralympic partnerships that focus on athlete development programs with substantive support
+- Sponsorships with explicit diversity, equity, and inclusion initiatives (beyond just marketing language)
+- Community investment programs beyond just product/uniform provision
+- Articles about athlete welfare, accessibility, or inclusive design
+
+## Sentiment Guidelines
+
+- **Positive (1)**: The brand is praised, making progress, exceeding standards, leading the industry, receiving awards, or taking proactive positive action.
+- **Neutral (0)**: Factual reporting, industry trends, announcements without clear positive/negative framing, balanced coverage of both sides.
+- **Negative (-1)**: Criticism, violations, failures, falling short of standards, scandals, lawsuits, negative incidents, or harm caused.
+
+## Evidence Requirements
+
+For each category label you assign, you MUST provide 1-3 direct quotes from the article that justify the classification. These quotes should be exact excerpts from the article text, not paraphrased. The quotes should clearly demonstrate why the category applies and support the sentiment you assigned.
+
+## Important Guidelines
+
+1. FIRST verify if each brand mention refers to the sportswear company or something else.
+2. Only assign ESG categories if the article is about the sportswear brand AND contains clear, relevant information.
+3. An article can have multiple categories if it covers multiple ESG topics.
+4. Different brands in the same article may have different categories and sentiments.
+5. If a brand is only briefly mentioned without substantive ESG-related content, do not assign categories for that brand.
+6. Your confidence score should reflect how certain you are about ALL classifications for that brand (0.0-1.0).
+
+## CRITICAL: Understanding is_sportswear_brand
+
+The `is_sportswear_brand` field indicates whether the article contains **substantive content** about the sportswear/apparel company. This determines whether the article is worth processing for potential ESG content or future analysis.
+
+**Set `is_sportswear_brand: false` when:**
+
+1. **Brand name refers to something ELSE entirely:**
+   - Puma the animal (not Puma sportswear)
+   - Patagonia the geographic region (not Patagonia outdoor apparel)
+   - "Vans" meaning vehicles (not Vans footwear)
+   - Puma Biotechnology, Columbia University (different entities)
+   - Sonoya Mizuno the actress (not Mizuno sportswear)
+
+2. **Financial articles with NO substantive commentary (this is a major error source):**
+
+   **Auto-generated institutional holdings articles** → `is_sportswear_brand: false`
+   These are template articles about hedge funds, pension funds, or advisory firms buying/selling shares. They contain only SEC filing data, share counts, and boilerplate financial metrics. Even though the sportswear brand name appears prominently (often in the title), there is ZERO substantive content about the brand's business.
+   - "Midwest Trust Co Invests $1.64 Million in NIKE, Inc." — just 13F filing data
+   - "Vontobel Holding Ltd. Boosts Position in Under Armour" — just share counts and moving averages
+   - "Thrivent Financial Has $26.71 Million Stake in Columbia Sportswear" — just portfolio disclosure
+   - "Park Place Capital Corp Boosts Holdings in lululemon" — just SEC filing data
+   - "OFI Invest Asset Management Buys 8,671 Shares of Deckers Outdoor" — just share purchase data
+
+   **Telltale signs of template stock articles** (almost always `is_sportswear_brand: false`):
+   - Phrases like "Get Free Report", "according to its most recent 13F filing"
+   - "The stock has a 200-day moving average of $X" / "50-day moving average"
+   - "Several other research analysts also recently issued reports"
+   - "shares of the footwear maker" / "shares of the textile maker" / "shares of the apparel retailer"
+   - Sources like MarketBeat, MarketScreener, HoldingsChannel, tickerreport.com, themarketsdaily.com
+
+   **Pure stock price/volume articles** → `is_sportswear_brand: false`
+   - "NKE stock up 4% today" — just price movement
+   - "Adidas (OTCMKTS:ADDYY) Sees Strong Trading Volume" — just volume data
+   - "Allbirds Stock Price Up 1.5% – What Next?" — price + boilerplate company profile
+   - "PUMA SE trading above 50-day moving average" — technical analysis only
+   - "Anta Sports Products Sees Unusually-High Trading Volume" — just volume spike data
+
+   **Short interest articles** → `is_sportswear_brand: false`
+   - "Short Interest in Adidas AG Rises By 88.3%" — just short interest numbers
+   - "Deckers Outdoor Sees Significant Decline in Short Interest" — just share counts
+
+   **Boilerplate analyst rating roundups** → `is_sportswear_brand: false`
+   These list analyst ratings/price targets WITHOUT explaining the reasoning behind them. They are just aggregated data:
+   - "Columbia Sportswear Receives Consensus Rating of 'Hold' from Analysts" — just a list of ratings
+   - "lululemon athletica Receives $227.15 Consensus PT from Analysts" — just averaged price targets
+   - "Columbia Sportswear Lowered to Sell Rating by Wall Street Zen" — rating change + boilerplate, no reasoning
+   - "Analysts Set Columbia Sportswear PT at $60.50" — just price target numbers
+   - "lululemon athletica 'Market Perform' Rating Reiterated at Telsey Advisory" — rating + no analysis
+
+   **Boilerplate stock comparison articles** → `is_sportswear_brand: false`
+   Side-by-side financial metric comparisons with no editorial analysis:
+   - "Reviewing Victoria's Secret & Allbirds" — just P/E, revenue, margins tables
+   - "Oxford Industries vs. Under Armour Head to Head Comparison" — just financial ratios
+   - "Comparing Hennes & Mauritz and 361 Degrees International" — just metric comparisons
+
+   **Auto-generated stock return calculators** → `is_sportswear_brand: false`
+   - "$100 Invested In Deckers Outdoor 20 Years Ago Would Be Worth This Much Today" — just math
+
+   **Shopping/deals/product promotion articles** → `is_sportswear_brand: false`
+   These are about buying products, not about the brand's business:
+   - "Skechers slippers 'perfect for cold months' reduced to £19" — product deal
+   - "Patagonia just added new gear to its New Arrivals section" — shopping guide
+   - "Converse Chuck Taylor heart sneakers at DSW for Valentine's Day" — product promotion
+   - "Brooks Running shoes: Adrenaline GTS 24 now $20 off" — sale listing
+   - "lululemon 'We Made Too Much' Section February 2026" — sale section roundup
+
+3. **Tangential mentions without substantive coverage:**
+   - Former executives now at other companies (article is about the OTHER company)
+   - Brand mentioned only as biographical context or comparison
+   - Industry reports where brand appears in a list without detail
+
+4. **Brand mentioned only as comparison, analogy, or reference point:**
+   - Color comparisons: "reminiscent of Nike's Infrared orange", "similar to Adidas' classic blue"
+   - Style comparisons: "gives off Patagonia vibes", "looks like something from Lululemon"
+   - Quality/reputation references: "built to Nike standards", "Adidas-level durability"
+   - Historical references: "back when Nike was just starting out"
+   - Aspiration analogies: "wants to be the Patagonia of baby clothes"
+   - The article's SUBJECT is something else; the brand is merely a point of reference
+
+**Set `is_sportswear_brand: true` (or omit the brand) when the article HAS substantive content:**
+
+- Product announcements, reviews, sales (→ true, but no ESG categories apply)
+- Store openings, sponsorships, athlete signings (→ true, but no ESG categories apply)
+- Financial articles **with substantive business commentary or analysis**:
+  - "Jim Cramer says Nike CEO is reinventing the company" → true (discusses strategy/management)
+  - "Analysts give Adidas Buy rating citing strong Q4 outlook" → true (discusses business prospects with reasoning)
+  - "Puma reports earnings beat driven by China growth" → true (discusses business performance with context)
+  - "Sinking 48%, Is Lululemon a Buying Opportunity?" → true (contains actual investment thesis with business analysis)
+  - "Nike Road to Recovery: Innovation, Competition, and Steady Dividend Growth" → true (discusses strategy)
+  - "Needham downgrades Nike citing brand weakness in North America" → true (analyst gives specific reasoning)
+  - "Deckers Racks Up Record Revenue as Significant Global Demand for Ugg and Hoka Continues" → true (discusses business performance with CEO quotes and segment analysis)
+
+**Key test for financial articles:** Would this article be useful if we added a "Finance" or "Business News" category?
+
+- **YES → `is_sportswear_brand: true`** if it contains: analyst reasoning, CEO/CFO quotes, business strategy discussion, competitive analysis, earnings with commentary on what drove results, investment thesis with company-specific analysis
+- **NO → `is_sportswear_brand: false`** if it contains only: raw stock price data, 13F filing share counts, moving averages, boilerplate analyst rating lists without reasoning, short interest numbers, template financial comparisons, auto-generated "X invested Y years ago" calculators
+
+**The critical distinction:** Does the article contain **human-written analysis or commentary** about the brand's business? Or is it **auto-generated/template content** that just plugs financial data into a standard format? Template content = false positive.

--- a/prompts/labeling/v1.10.0/user_prompt.txt
+++ b/prompts/labeling/v1.10.0/user_prompt.txt
@@ -1,0 +1,69 @@
+Analyze this news article for ESG classifications for each brand mentioned.
+
+**Article Title**: {title}
+**Publication Date**: {published_at}
+**Source**: {source_name}
+**Brands to Analyze**: {brands}
+
+**Article Content**:
+{content}
+
+---
+
+For each brand mentioned, FIRST verify if it refers to the sportswear/apparel company. Then provide ESG analysis only for confirmed sportswear brands with substantive content.
+
+Respond in the following JSON format:
+
+```json
+{{
+  "brand_analyses": [
+    {{
+      "brand": "Brand Name",
+      "is_sportswear_brand": true,
+      "not_sportswear_reason": null,
+      "categories": {{
+        "environmental": {{
+          "applies": true,
+          "sentiment": 1,
+          "evidence": ["Direct quote from article...", "Another supporting quote..."]
+        }},
+        "social": {{
+          "applies": false,
+          "sentiment": null,
+          "evidence": []
+        }},
+        "governance": {{
+          "applies": true,
+          "sentiment": 0,
+          "evidence": ["Direct quote..."]
+        }},
+        "digital_transformation": {{
+          "applies": false,
+          "sentiment": null,
+          "evidence": []
+        }}
+      }},
+      "confidence": 0.85,
+      "reasoning": "Brief explanation of why these classifications were assigned"
+    }},
+    {{
+      "brand": "Puma",
+      "is_sportswear_brand": false,
+      "not_sportswear_reason": "Article is about puma (wildcat/mountain lion), not Puma sportswear",
+      "categories": {{}},
+      "confidence": 0.95,
+      "reasoning": "Brand name refers to the animal, not the sportswear company"
+    }}
+  ],
+  "article_summary": "1-2 sentence summary of the article's main themes"
+}}
+```
+
+Important reminders:
+- FIRST check if each brand refers to the sportswear company or something else (animal, region, car, etc.)
+- If NOT a sportswear brand: set `is_sportswear_brand: false`, explain in `not_sportswear_reason`, leave `categories` empty
+- If IS a sportswear brand: set `is_sportswear_brand: true`, `not_sportswear_reason: null`, fill in categories
+- Only set `applies: true` if the article contains clear, relevant ESG information for that category
+- Sentiment must be -1, 0, or 1 when applies is true; null when applies is false
+- Evidence quotes MUST be exact text from the article
+- **CRITICAL: If a sportswear brand has NO applicable ESG categories (all categories would be applies: false), DO NOT include that brand in brand_analyses at all.** Only include brands that have at least one category with applies: true. A brand mentioned only as a competitor, reference point, or context (e.g., "Nike's biggest Chinese challenger") should be omitted entirely if it has no ESG content of its own.

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -45,7 +45,7 @@ class AgentSettings:
     )
     llm_analysis_model: str = field(
         default_factory=lambda: os.getenv(
-            "AGENT_LLM_MODEL", "claude-sonnet-4-6"
+            "AGENT_LLM_MODEL", "claude-haiku-4-5-20251001"
         )
     )
 

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -1,6 +1,6 @@
 """LLM-based analysis for agent workflows.
 
-Uses Claude Sonnet via the Anthropic API to analyze labeling results,
+Uses Claude via the Anthropic API to analyze labeling results,
 detect patterns in errors, and suggest improvements.
 """
 
@@ -16,14 +16,14 @@ from .config import agent_settings
 
 logger = logging.getLogger(__name__)
 
-# Analysis model - use Sonnet for cost efficiency
+# Analysis model default (override via AGENT_LLM_MODEL); a cost-efficient tier suffices for advisory QA
 DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
-# Max output tokens for the analysis call. Sonnet 4.6 produces a richer analysis
-# than the retired Sonnet 4, so the old 2000 cap truncated the JSON mid-structure
-# (see issue #42). Give generous headroom; the prompt also bounds list lengths so
-# responses stay well under this in practice. Non-streaming, so kept under the
-# ~16K SDK HTTP-timeout guideline.
+# Max output tokens for the analysis call. The old 2000 cap truncated the JSON
+# mid-structure under Sonnet 4.6's verbosity (issue #42), so it was raised to 8000.
+# Haiku 4.5 is less verbose, but the headroom is kept; the prompt also bounds list
+# lengths so responses stay well under this in practice. Non-streaming, so kept
+# under the ~16K SDK HTTP-timeout guideline.
 ANALYSIS_MAX_TOKENS = 8000
 
 

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -17,7 +17,7 @@ from .config import agent_settings
 logger = logging.getLogger(__name__)
 
 # Analysis model - use Sonnet for cost efficiency
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
 # Max output tokens for the analysis call. Sonnet 4.6 produces a richer analysis
 # than the retired Sonnet 4, so the old 2000 cap truncated the JSON mid-structure
@@ -130,7 +130,7 @@ class LabelingAnalyzer:
 
         Args:
             api_key: Anthropic API key (default: from environment)
-            model: Model to use (default: claude-sonnet-4-6)
+            model: Model to use (default: claude-haiku-4-5-20251001)
             max_retries: Maximum retry attempts for rate limits
             retry_delay: Initial delay between retries in seconds
         """

--- a/src/agent/workflows/daily_labeling.py
+++ b/src/agent/workflows/daily_labeling.py
@@ -229,7 +229,7 @@ def run_llm_analysis(workflow: Workflow, context: dict[str, Any]) -> dict[str, A
     - If AGENT_LLM_ANALYSIS=true and AGENT_LLM_ERROR_THRESHOLD=0.0: always run
     - If AGENT_LLM_ERROR_THRESHOLD > 0: only run if error_rate exceeds threshold
 
-    Uses Claude Sonnet to analyze recent labeling results and identify:
+    Uses Claude to analyze recent labeling results and identify:
     - Potential labeling errors
     - Patterns in false positives
     - Improvement suggestions

--- a/src/experiment_log/reflection.py
+++ b/src/experiment_log/reflection.py
@@ -16,7 +16,7 @@ from .models import ExperimentEntry, ExperimentReflection
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
 REFLECTION_SYSTEM_PROMPT = """You are an ML experiment analyst reviewing a completed model training experiment.
 

--- a/src/labeling/config.py
+++ b/src/labeling/config.py
@@ -95,7 +95,7 @@ class LabelingSettings(BaseModel):
 
     # Model settings
     labeling_model: str = Field(
-        default_factory=lambda: os.getenv("LABELING_MODEL", "claude-sonnet-4-6")
+        default_factory=lambda: os.getenv("LABELING_MODEL", "claude-haiku-4-5-20251001")
     )
 
     # Prompt version (None = use production version from registry)

--- a/src/labeling/database.py
+++ b/src/labeling/database.py
@@ -305,9 +305,9 @@ class LabelingDatabase:
         run.error_message = error_message
 
         # Calculate estimated cost
-        # Claude Sonnet: $3/1M input, $15/1M output
+        # Claude Haiku 4.5: $1/1M input, $5/1M output (model-aware pricing tracked in #54)
         # OpenAI embeddings: $0.00002/1K tokens
-        llm_cost = (input_tokens / 1_000_000) * 3 + (output_tokens / 1_000_000) * 15
+        llm_cost = (input_tokens / 1_000_000) * 1 + (output_tokens / 1_000_000) * 5
         # Rough estimate for embedding tokens (assume similar to chunk count)
         embedding_cost = (embeddings_generated * 500 / 1000) * 0.00002
         run.estimated_cost_usd = llm_cost + embedding_cost

--- a/src/labeling/labeler.py
+++ b/src/labeling/labeler.py
@@ -585,10 +585,11 @@ class ArticleLabeler:
         Returns:
             Dictionary with usage statistics
         """
-        # Cost estimates for Claude Sonnet
-        # Input: $3.00 per 1M tokens, Output: $15.00 per 1M tokens
-        input_cost = (self.total_input_tokens / 1_000_000) * 3.00
-        output_cost = (self.total_output_tokens / 1_000_000) * 15.00
+        # Cost estimate for the production labeling model (Claude Haiku 4.5):
+        # Input: $1.00 per 1M tokens, Output: $5.00 per 1M tokens.
+        # Hardcoded to the current model; model-aware pricing is tracked in #54.
+        input_cost = (self.total_input_tokens / 1_000_000) * 1.00
+        output_cost = (self.total_output_tokens / 1_000_000) * 5.00
 
         return {
             "total_input_tokens": self.total_input_tokens,

--- a/src/workflow_learning/config.py
+++ b/src/workflow_learning/config.py
@@ -43,7 +43,7 @@ class WorkflowLearningSettings:
     # Analysis settings
     analysis_model: str = field(
         default_factory=lambda: os.getenv(
-            "WORKFLOW_ANALYSIS_MODEL", "claude-sonnet-4-6"
+            "WORKFLOW_ANALYSIS_MODEL", "claude-haiku-4-5-20251001"
         )
     )
     anthropic_api_key: str | None = field(

--- a/tests/test_agent_llm.py
+++ b/tests/test_agent_llm.py
@@ -24,7 +24,7 @@ class TestAnalysisResult:
             analysis={"summary": "Good quality labeling"},
             input_tokens=100,
             output_tokens=50,
-            model="claude-sonnet-4-6",
+            model="claude-haiku-4-5-20251001",
         )
 
         assert result.success is True
@@ -38,7 +38,7 @@ class TestAnalysisResult:
         result = AnalysisResult(
             success=False,
             error="API error occurred",
-            model="claude-sonnet-4-6",
+            model="claude-haiku-4-5-20251001",
         )
 
         assert result.success is False

--- a/tests/test_experiment_log/test_workflow_integration.py
+++ b/tests/test_experiment_log/test_workflow_integration.py
@@ -171,7 +171,7 @@ class TestFinalizeExperiments:
 
         mock_settings.llm_analysis_enabled = True
         mock_settings.anthropic_api_key = "test-key"
-        mock_settings.llm_analysis_model = "claude-sonnet-4-6"
+        mock_settings.llm_analysis_model = "claude-haiku-4-5-20251001"
 
         context = {
             "experiment_ids": {"fp": "fp_20260226_143000"},

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -681,8 +681,8 @@ class TestArticleLabelerStats:
 
             stats = labeler.get_stats()
 
-            # Input: $3.00 per 1M, Output: $15.00 per 1M
-            expected_cost = 3.00 + 15.00
+            # Claude Haiku 4.5 — Input: $1.00 per 1M, Output: $5.00 per 1M
+            expected_cost = 1.00 + 5.00
             assert abs(stats["estimated_cost_usd"] - expected_cost) < 0.01
 
 

--- a/tests/test_workflow_learning/test_config.py
+++ b/tests/test_workflow_learning/test_config.py
@@ -33,7 +33,7 @@ class TestWorkflowLearningSettings:
             from src.workflow_learning.config import WorkflowLearningSettings
 
             settings = WorkflowLearningSettings()
-            assert settings.analysis_model == "claude-sonnet-4-6"
+            assert settings.analysis_model == "claude-haiku-4-5-20251001"
 
     def test_sessions_dir_property(self, tmp_path):
         """Test sessions_dir property."""

--- a/tests/test_workflow_learning/test_models.py
+++ b/tests/test_workflow_learning/test_models.py
@@ -332,7 +332,7 @@ class TestAnalysisResult:
             skill_description="A test workflow",
             input_tokens=1000,
             output_tokens=500,
-            model="claude-sonnet-4-6",
+            model="claude-haiku-4-5-20251001",
         )
 
         assert result.success is True
@@ -346,7 +346,7 @@ class TestAnalysisResult:
         result = AnalysisResult(
             success=False,
             error="API rate limited",
-            model="claude-sonnet-4-6",
+            model="claude-haiku-4-5-20251001",
         )
 
         assert result.success is False

--- a/tests/test_workflow_learning/test_skill_generator.py
+++ b/tests/test_workflow_learning/test_skill_generator.py
@@ -71,7 +71,7 @@ def sample_analysis():
         skill_description="Train the false positive classifier model",
         input_tokens=2000,
         output_tokens=800,
-        model="claude-sonnet-4-6",
+        model="claude-haiku-4-5-20251001",
     )
 
 


### PR DESCRIPTION
## Summary
Migrates the labeling model from Claude Sonnet 4.6 to **Claude Haiku 4.5** (pinned snapshot `claude-haiku-4-5-20251001`) — a cost-downgrade, ~67% cheaper, with `temperature=0` and the tokenizer family unchanged. Closes #53.

## Motivation
Cost — without the downsides of Sonnet 5, which we evaluated and rejected: Sonnet 5's ~30% tokenizer inflation erases its introductory discount (net *more* expensive than 4.6 after the intro window) and it rejects non-default `temperature` with a 400, removing the determinism the scorecard relies on. Full rationale in #53.

## Validation (eval-gated)
Retrospective contrastive eval (`scripts/eval_model_migration.py`) — Haiku 4.5 vs Sonnet 4.6 / v1.9.0, 162 articles, frozen prompt:

| Guardrail | Result | |
|---|---|---|
| `newly_labeled_rate` (scorecard-inflation risk; labeler is the only junk gate, FP/EP pre-filters are disabled) | **0.0%** | ✅ |
| `sentiment_exact` | **93.9%** (≥ 4.6's 92.4%) | ✅ |
| parse / truncation failures | **0** | ✅ |
| cost (this run) | ~$1.82 | |

Disagreements were dominated by Haiku *correctly* rejecting brand-collision / financial / marketing false positives that 4.6 mislabeled (e.g. "Anta" = Antalpha crypto ticker, "Vans" = cargo vans, stock/marketing pieces). The macro-F1 advisory flag (0.571) is an **artifact of those correct drops** cascading into category false-negatives, not a category blind spot — verified: all 10 `digital_transformation` FNs come from whole-article drops, 0 from kept-but-omitted. Full report: `data/evaluation/migration/migration_eval_20260701T074742Z.md`.

Statistical power on positives is low (30 labeled, 1 human anchor) — mitigated by the post-merge drift-monitoring step below.

## Changes
- **Prompt v1.10.0**: byte-identical text to v1.9.0, model → Haiku snapshot; promoted to production in `registry.json` (v1.9.0 → superseded).
- **All 5 Sonnet 4.6 call sites → Haiku snapshot**: labeling (`src/labeling/config.py`, eval-gated) + agent analysis, workflow-learning, experiment reflection (ungated, low-stakes, revertible).
- **Docs**: model-agnostic prose ("Claude Sonnet" → "Claude"); corrected labeling cost estimate ($10-15 → $3-5 per 1000); CHANGELOG entry.
- **Cost accounting**: corrected hardcoded Sonnet pricing → Haiku 4.5 in `ArticleLabeler.get_stats()` and the labeling-run cost estimate (production logging was overreporting ~3×); model-aware pricing tracked in #54. Stale "Claude Sonnet" comments/docstrings made model-agnostic.
- **Tests**: updated assertions (incl. cost). Full suite green — **1271 passed, 26 skipped**.

## Post-merge (please do)
- [x] `.env.example` — model vars pointed at `claude-haiku-4-5-20251001` (`LABELING_MODEL`, `WORKFLOW_ANALYSIS_MODEL`, plus newly-added `AGENT_LLM_MODEL`); committed in this PR.
- [ ] After the first Haiku labeling batch, run a **drift-monitoring window** to confirm no distribution shift — the compensation for the low-power eval.

## Follow-ups
- **#54** — reusable model-migration skill (this migration is its worked cost-downgrade example).
- **#55** — Allbirds corporate-pivot labeling decision-boundary (deferred; a prompt-policy question, not a model issue — Haiku was consistent where 4.6 was erratic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
